### PR TITLE
docs: seed claim harness project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.nox/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Environment and local config
+.env
+.env.*
+!.env.example
+
+# Build and packaging output
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Coverage output
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Logs and temporary files
+*.log
+*.tmp
+*.temp
+.cache/
+tmp/
+temp/
+
+# OS and editor files
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# Claim Harness
+
+**Evaluate whether agentic PRs have enough test evidence to support their change claims - not just covered lines or passing CI.**
+
+Claim Harness is a documentation-first project seed for evaluating the test evidence behind AI-generated pull requests. It focuses on the review question that normal CI and coverage reports often leave unanswered: did the tests actually support the behavior the PR claims to change?
+
+## Why This Exists
+
+AI coding agents can now turn an issue, task description, or PR comment into a complete pull request. Reviewers often start with familiar signals: CI passed, tests ran, and changed lines were covered. Those signals are useful, but they do not prove that the intended behavior was tested.
+
+The risky case is a PR that looks tested while its evidence is thin:
+
+- The changed code executed, but no meaningful assertion constrained the behavior.
+- Tests exercised a fallback path but never checked the failure mode.
+- Mocks replaced the core path the PR claims to fix.
+- The issue asked for one behavior, while the test targets a nearby but different one.
+- CI passed because the relevant test scope was narrowed.
+
+Claim Harness treats coverage as one piece of an evidence chain, not as the final answer.
+
+## What It Evaluates
+
+Claim Harness is centered on this evaluation frame:
+
+```text
+change claim -> evidence chain -> counterfactual probe -> mock boundary -> adequacy findings
+```
+
+It aims to connect:
+
+- **Change claims:** what the PR says it changed, from the issue, PR text, commits, and diff.
+- **Evidence chains:** which tests, assertions, coverage spans, and CI runs support each claim.
+- **Counterfactual probes:** whether tests would fail if the claimed behavior were removed or weakened.
+- **Mock boundaries:** whether tests replace the behavior they are supposed to validate.
+- **Adequacy findings:** reviewable conclusions about missing, weak, mismatched, or complete evidence.
+
+Initial finding concepts include:
+
+| Finding | Meaning |
+| --- | --- |
+| `Missing Test Evidence` | A claim has no clear test evidence attached. |
+| `Uncovered Changed Lines` | Changed behavior is not executed by the relevant tests. |
+| `Weak Assertion` | Code is executed, but assertions do not constrain the claimed behavior. |
+| `Issue-Test Mismatch` | Tests target a different behavior than the issue or claim describes. |
+| `Suspicious Fix Without Test` | A behavioral fix appears in the diff without a corresponding test change or existing test link. |
+| `Mocked Core Path` | The test mocks or stubs the path that should provide evidence. |
+| `CI Scope Weakening` | The tested CI scope appears narrower than the PR's affected behavior. |
+| `Counterfactual Survivor` | A weakened or removed behavior still passes the attached tests. |
+| `Evidence Complete` | The current evidence chain is relatively complete; this does not mean the PR is correct. |
+
+## What It Is Not
+
+- Not a generic coverage reporter.
+- Not a SWE-bench clone.
+- Not a test generation agent.
+- Not a pure LLM judge.
+- Not a replacement for human review.
+
+SWE-bench-style evaluations ask whether an agent can solve an issue. Patch coverage tools ask whether changed lines were executed. Test generation benchmarks ask whether tests can be produced. Claim Harness starts later in the lifecycle: an agent has already submitted a PR, and a reviewer needs to understand whether the PR's tests support its claims.
+
+## Core Workflow
+
+1. **Extract claims** from the issue, task text, PR description, commits, and diff.
+2. **Map evidence** from test diffs, existing tests, coverage output, and CI logs.
+3. **Check alignment** between each claim and the tests that allegedly support it.
+4. **Probe counterfactuals** by weakening or removing claimed behavior and observing whether tests fail.
+5. **Inspect mock boundaries** to identify tests that skip the core behavior.
+6. **Report findings** in a form a human reviewer can audit and challenge.
+
+## First-Version Scope
+
+This first version seeds the project direction and documentation only. It does not add implementation code, a CLI, a runner, curated benchmark cases, or baseline comparisons.
+
+The initial docs focus on:
+
+- [Methodology](docs/methodology.md): how claims, evidence chains, probes, and mock-boundary checks fit together.
+- [Roadmap](docs/roadmap.md): the intended MVP boundary and staged evolution.
+
+## Later Direction
+
+Future work can add a small curated Python/pytest case set, a reproducible runner skeleton, expected finding formats, baseline comparisons, counterfactual probes, and mock boundary analysis. The goal is to make evidence adequacy review repeatable without pretending that any automated harness can prove a PR correct.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,0 +1,72 @@
+# Methodology
+
+Claim Harness evaluates whether the evidence behind a pull request is adequate for the claims the pull request makes. The intended unit is not a file, line, or test count. The intended unit is a claim-evidence relationship that a reviewer can inspect.
+
+The working frame is:
+
+```text
+change claim -> evidence chain -> counterfactual probe -> mock boundary -> adequacy findings
+```
+
+## Claim Extraction
+
+A change claim is a specific statement about behavior the PR is expected to alter or preserve. Claims may come from an issue, task description, PR body, commit message, code diff, or test name.
+
+Examples:
+
+- Empty passwords should return HTTP 400 instead of creating an account.
+- Invalid cache metadata should fall back to a cold read.
+- The retry loop should stop after the configured maximum.
+
+Claim extraction should keep claims narrow enough to attach evidence. A broad statement such as "improve auth validation" is less useful than "empty passwords return 400 and do not create a user."
+
+## Evidence Chain
+
+An evidence chain links a claim to the artifacts that support it:
+
+- The code diff that implements the claimed behavior.
+- The test diff or existing tests that exercise it.
+- Assertions that constrain the expected outcome.
+- Coverage spans showing which changed code ran.
+- CI logs showing which test commands ran.
+
+Coverage is necessary evidence in many cases, but it is not sufficient. A line can be covered by a test that only checks that a result exists, never that the intended behavior occurred.
+
+## Coverage Mapping
+
+Coverage mapping asks which changed lines and branches were executed by tests that are relevant to the claim. It helps identify `Uncovered Changed Lines`, but it should not be treated as the final adequacy signal.
+
+Useful coverage questions include:
+
+- Did the changed branch execute at all?
+- Was it executed by a test related to the issue claim?
+- Did the test assert the behavior the branch is supposed to enforce?
+- Did CI run the relevant test target, or only a narrowed subset?
+
+## Counterfactual Probe
+
+A counterfactual probe weakens, removes, or alters the claimed behavior and checks whether the attached tests fail. If tests still pass, the claim may have a `Counterfactual Survivor` finding.
+
+Example:
+
+An issue says empty passwords must return HTTP 400. The PR adds an empty-password branch, and a test executes the branch, but the only assertion is `result is not None`. Coverage says the new branch ran. If a probe removes the empty-password branch and the test still passes, the test did not actually constrain the 400 behavior.
+
+That case is both a `Weak Assertion` and a `Counterfactual Survivor`: the code was covered, but the evidence did not support the claim.
+
+## Mock Boundary Analysis
+
+Mock boundary analysis asks whether a test replaces the core behavior it is supposed to validate. Mocks are not inherently bad; they become evidence problems when they bypass the behavior named in the claim.
+
+Examples:
+
+- A PR claims to fix payment retry behavior, but the test mocks the retry loop itself.
+- A PR claims to harden parser error handling, but the test mocks the parser output.
+- A PR claims a fallback path works, but the test mocks the failing dependency and never asserts the fallback result.
+
+The key question is whether the mocked boundary still leaves a meaningful behavior path under test.
+
+## Adequacy Findings
+
+Findings should be concrete and reviewable. They should point to the claim, the evidence considered, and the reason the evidence is missing, weak, mismatched, or relatively complete.
+
+`Evidence Complete` is deliberately modest. It means the current evidence chain appears adequate for the stated claim under the harness checks. It does not mean the implementation is correct, secure, performant, or ready to merge without human review.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,74 @@
+# Roadmap and MVP Scope
+
+Claim Harness starts as a documentation and methodology seed. The first implementation should stay narrow: enough structure to evaluate a few real pull requests reproducibly, without turning into a general agent benchmark or a broad test-generation system.
+
+## Current Scope
+
+This repository currently contains the initial documentation only:
+
+- Project positioning and workflow in `README.md`.
+- Evaluation methodology in `docs/methodology.md`.
+- MVP boundary and staged roadmap in this document.
+
+There is no runner, CLI, benchmark case set, baseline comparison, or finding schema implementation yet.
+
+## Ecosystem Position
+
+Claim Harness is adjacent to several existing categories, but it asks a different question.
+
+| Category | Typical question | Claim Harness question |
+| --- | --- | --- |
+| SWE-bench-style issue benchmarks | Can the agent solve the issue? | After the agent submits a PR, do the tests support the PR's claims? |
+| Patch coverage tools | Did tests execute changed lines? | Did executed tests assert the claimed behavior? |
+| Test generation benchmarks | Can tests be generated for code? | Are the tests attached to this PR adequate evidence? |
+| Agentic PR empirical studies | What patterns appear across generated PRs? | Can a reviewer inspect evidence adequacy for one PR reproducibly? |
+
+The project should use restrained claims about novelty. The useful distinction is lifecycle and evidence focus, not a claim that related work is irrelevant.
+
+## MVP Boundary
+
+The first practical MVP should aim for a small, inspectable workflow:
+
+1. Curated Python/pytest cases with known weak and adequate evidence patterns.
+2. A minimal claim and finding format.
+3. A runner skeleton that can collect test output and coverage.
+4. Manual or semi-structured claim extraction before full automation.
+5. Baseline comparison against simple coverage-only rules.
+
+The MVP should avoid:
+
+- Generating tests automatically.
+- Running arbitrary untrusted repositories without isolation design.
+- Scoring PR correctness.
+- Treating an LLM judgment as the only evidence source.
+- Expanding into many languages before the evaluation shape is stable.
+
+## Staged Evolution
+
+### Stage 1: Curated Cases
+
+Add a small set of intentionally simple Python/pytest examples. Each case should have a PR-like diff, an issue claim, test evidence, and expected findings such as `Weak Assertion`, `Mocked Core Path`, or `Evidence Complete`.
+
+### Stage 2: Runner Skeleton
+
+Add a lightweight runner that can execute tests, collect coverage, and emit raw artifacts. The runner should preserve evidence rather than immediately compressing it into a single score.
+
+### Stage 3: Findings Format
+
+Define a stable report shape that links each finding to claims, tests, coverage spans, probes, and CI evidence. The format should be easy to review in a PR comment or local artifact.
+
+### Stage 4: Counterfactual Probes
+
+Introduce controlled probes for selected cases. Early probes can be simple mutations that remove or weaken the claimed behavior, with clear limits and reproducibility notes.
+
+### Stage 5: Mock Boundary Analysis
+
+Add heuristics and language-specific analysis for identifying when mocks replace the core path under review. This should start with explicit patterns in curated cases before expanding.
+
+## Design Principles
+
+- Evidence should be auditable by humans.
+- Findings should explain why evidence is adequate or inadequate.
+- Coverage should remain an input, not the final answer.
+- Benchmarks should prefer small, clear cases before scale.
+- The harness should help reviewers find risk, not certify correctness.


### PR DESCRIPTION
## Summary
Seed the initial documentation structure for Claim Harness.

This PR adds:
- README.md with project positioning, scope, workflow, and initial finding types
- .gitignore for a future Python-based implementation
- A small docs/ structure covering methodology and roadmap/MVP scope, with ecosystem positioning kept in README/roadmap

## Scope
This is a documentation-only initialization PR. It does not add runner code, cases, baselines, or CLI implementation yet.

## Next steps
After this lands, the next step is to add a small curated Python/pytest case set and define the first expected findings format.