### PR TITLE
eval: add curated benchmark foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,61 @@ SWE-bench-style evaluations ask whether an agent can solve an issue. Patch cover
 5. **Inspect mock boundaries** to identify tests that skip the core behavior.
 6. **Report findings** in a form a human reviewer can audit and challenge.
 
-## First-Version Scope
+## Curated Benchmark Foundation
 
-This first version seeds the project direction and documentation only. It does not add implementation code, a CLI, a runner, curated benchmark cases, or baseline comparisons.
+The repository now includes the first executable Python/pytest micro-PR cases under `cases/python/`.
 
-The initial docs focus on:
+The initial cases intentionally isolate four evidence patterns:
+
+- `weak_assertion_001`
+- `issue_test_mismatch_001`
+- `mocked_core_path_001`
+- `evidence_complete_001`
+
+Each case includes an issue, structured claim, executable repository fixture, PR-like patch, metadata, and expected findings defined independently from Claim Harness output.
+
+The benchmark foundation is intentionally small. Its purpose is to stabilize the case contract and ground-truth rules before implementing the full runner or automated semantic analysis.
+
+Validate the case structure:
+
+```bash
+python3 scripts/validate_cases.py
+```
+
+Apply each patch in a temporary copy and run the patched pytest fixture:
+
+```bash
+python3 scripts/validate_cases.py --run
+```
+
+The `--run` mode requires `git` and `pytest` in the local environment.
+
+## Project Documents
 
 - [Methodology](docs/methodology.md): how claims, evidence chains, probes, and mock-boundary checks fit together.
-- [Evaluation Design](docs/evaluation-design.md): how future cases, baselines, findings, and expected outputs should be organized.
-- [Roadmap](docs/roadmap.md): the intended MVP boundary and staged evolution.
+- [Evaluation Design](docs/evaluation-design.md): how cases, baselines, findings, and expected outputs are organized.
+- [Annotation Guidelines](docs/annotation-guidelines.md): how human ground truth should be created without using Claim Harness output.
+- [Benchmark Protocol](docs/benchmark-protocol.md): how coverage, heuristic, LLM, and Claim Harness methods should be compared.
+- [Roadmap](docs/roadmap.md): the MVP boundary and staged evolution.
+
+## Current Scope
+
+This repository now contains documentation plus the first executable benchmark fixtures and a lightweight case validator.
+
+It still does **not** include:
+
+- the Claim Harness runner;
+- automated claim extraction;
+- per-test coverage mapping;
+- automated LLM semantic reasoning;
+- automated mock-boundary classification;
+- counterfactual generation;
+- GitHub Action integration.
+
+The next implementation stage is a lightweight runner that can execute tests, collect coverage, and preserve raw evidence for later claim-centered analysis.
 
 ## Later Direction
 
-Future work can add a small curated Python/pytest case set, a reproducible runner skeleton, expected finding formats, baseline comparisons, counterfactual probes, and mock boundary analysis. The goal is to make evidence adequacy review repeatable without pretending that any automated harness can prove a PR correct.
+Future work can add the runner, stable finding schemas, baseline implementations, per-test coverage, semantic claim alignment, mock-boundary analysis, controlled counterfactual probes, and real-world agentic PR evaluation.
+
+The goal is to make evidence-adequacy review repeatable without pretending that any automated harness can prove a PR correct.

--- a/cases/python/evidence_complete_001/claim.json
+++ b/cases/python/evidence_complete_001/claim.json
@@ -1,0 +1,18 @@
+{
+  "claims": [
+    {
+      "id": "C1",
+      "text": "Creating a user with an empty password returns HTTP 400.",
+      "trigger": "password is empty",
+      "expected_outcome": "HTTP status 400",
+      "source": "issue.md"
+    },
+    {
+      "id": "C2",
+      "text": "Creating a user with an empty password does not persist a user.",
+      "trigger": "password is empty",
+      "expected_outcome": "repository remains unchanged",
+      "source": "issue.md"
+    }
+  ]
+}

--- a/cases/python/evidence_complete_001/expected_findings.json
+++ b/cases/python/evidence_complete_001/expected_findings.json
@@ -1,0 +1,31 @@
+{
+  "case_id": "evidence_complete_001",
+  "claims": [
+    {
+      "claim_id": "C1",
+      "adequacy": "supported",
+      "findings": [
+        {
+          "type": "Evidence Complete",
+          "evidence_refs": [
+            "repo/tests/test_users.py::test_empty_password_is_rejected"
+          ],
+          "rationale": "The test directly asserts the HTTP 400 outcome required by the claim."
+        }
+      ]
+    },
+    {
+      "claim_id": "C2",
+      "adequacy": "supported",
+      "findings": [
+        {
+          "type": "Evidence Complete",
+          "evidence_refs": [
+            "repo/tests/test_users.py::test_empty_password_is_rejected"
+          ],
+          "rationale": "The same test directly asserts that no user was persisted for the rejected request."
+        }
+      ]
+    }
+  ]
+}

--- a/cases/python/evidence_complete_001/issue.md
+++ b/cases/python/evidence_complete_001/issue.md
@@ -1,0 +1,3 @@
+# Empty-password validation with no user creation
+
+Creating a user with an empty password must return HTTP 400 and must not persist a user. Valid passwords should continue to create users successfully.

--- a/cases/python/evidence_complete_001/metadata.json
+++ b/cases/python/evidence_complete_001/metadata.json
@@ -1,0 +1,8 @@
+{
+  "language": "python",
+  "test_framework": "pytest",
+  "fixture_kind": "executable_micro_pr",
+  "ground_truth_source": "controlled_construction",
+  "case_id": "evidence_complete_001",
+  "case_family": "Evidence Complete"
+}

--- a/cases/python/evidence_complete_001/pr.patch
+++ b/cases/python/evidence_complete_001/pr.patch
@@ -1,0 +1,26 @@
+diff --git a/users.py b/users.py
+--- a/users.py
++++ b/users.py
+@@ -18,5 +18,7 @@
+ 
+ 
+ def create_user(password: str, repository: UserRepository) -> Response:
++    if not password:
++        return Response(status_code=400)
+     repository.add(password)
+     return Response(status_code=201)
+diff --git a/tests/test_users.py b/tests/test_users.py
+--- a/tests/test_users.py
++++ b/tests/test_users.py
+@@ -7,3 +7,11 @@
+ 
+     assert response.status_code == 201
+     assert repository.count() == 1
++
++
++def test_empty_password_is_rejected():
++    repository = UserRepository()
++    response = create_user("", repository)
++
++    assert response.status_code == 400
++    assert repository.count() == 0

--- a/cases/python/evidence_complete_001/repo/tests/test_users.py
+++ b/cases/python/evidence_complete_001/repo/tests/test_users.py
@@ -1,0 +1,9 @@
+from users import UserRepository, create_user
+
+
+def test_valid_password_creates_user():
+    repository = UserRepository()
+    response = create_user("secret", repository)
+
+    assert response.status_code == 201
+    assert repository.count() == 1

--- a/cases/python/evidence_complete_001/repo/users.py
+++ b/cases/python/evidence_complete_001/repo/users.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Response:
+    status_code: int
+
+
+class UserRepository:
+    def __init__(self):
+        self.users = []
+
+    def add(self, password: str) -> None:
+        self.users.append(password)
+
+    def count(self) -> int:
+        return len(self.users)
+
+
+def create_user(password: str, repository: UserRepository) -> Response:
+    repository.add(password)
+    return Response(status_code=201)

--- a/cases/python/issue_test_mismatch_001/claim.json
+++ b/cases/python/issue_test_mismatch_001/claim.json
@@ -1,0 +1,11 @@
+{
+  "claims": [
+    {
+      "id": "C1",
+      "text": "Logging in with an expired token returns HTTP 401.",
+      "trigger": "token is expired",
+      "expected_outcome": "HTTP status 401",
+      "source": "issue.md"
+    }
+  ]
+}

--- a/cases/python/issue_test_mismatch_001/expected_findings.json
+++ b/cases/python/issue_test_mismatch_001/expected_findings.json
@@ -1,0 +1,23 @@
+{
+  "case_id": "issue_test_mismatch_001",
+  "claims": [
+    {
+      "claim_id": "C1",
+      "adequacy": "unsupported",
+      "findings": [
+        {
+          "type": "Issue-Test Mismatch",
+          "evidence_refs": [
+            "repo/tests/test_auth.py::test_valid_token_still_succeeds"
+          ],
+          "rationale": "The added test validates the valid-token success path, while the claim is specifically about expired-token rejection."
+        },
+        {
+          "type": "Missing Test Evidence",
+          "evidence_refs": [],
+          "rationale": "No test in the submitted fixture checks the expired-token behavior required by the claim."
+        }
+      ]
+    }
+  ]
+}

--- a/cases/python/issue_test_mismatch_001/issue.md
+++ b/cases/python/issue_test_mismatch_001/issue.md
@@ -1,0 +1,3 @@
+# Expired-token handling
+
+Logging in with an expired token must return HTTP 401. Valid tokens should continue to return HTTP 200.

--- a/cases/python/issue_test_mismatch_001/metadata.json
+++ b/cases/python/issue_test_mismatch_001/metadata.json
@@ -1,0 +1,8 @@
+{
+  "language": "python",
+  "test_framework": "pytest",
+  "fixture_kind": "executable_micro_pr",
+  "ground_truth_source": "controlled_construction",
+  "case_id": "issue_test_mismatch_001",
+  "case_family": "Issue-Test Mismatch"
+}

--- a/cases/python/issue_test_mismatch_001/pr.patch
+++ b/cases/python/issue_test_mismatch_001/pr.patch
@@ -1,0 +1,21 @@
+diff --git a/auth.py b/auth.py
+--- a/auth.py
++++ b/auth.py
+@@ -7,4 +7,6 @@
+ 
+ 
+ def login(token: Token) -> int:
++    if token.expired:
++        return 401
+     return 200
+diff --git a/tests/test_auth.py b/tests/test_auth.py
+--- a/tests/test_auth.py
++++ b/tests/test_auth.py
+@@ -3,3 +3,7 @@
+ 
+ def test_valid_token():
+     assert login(Token(expired=False)) == 200
++
++
++def test_valid_token_still_succeeds():
++    assert login(Token(expired=False)) == 200

--- a/cases/python/issue_test_mismatch_001/repo/auth.py
+++ b/cases/python/issue_test_mismatch_001/repo/auth.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Token:
+    expired: bool = False
+
+
+def login(token: Token) -> int:
+    return 200

--- a/cases/python/issue_test_mismatch_001/repo/tests/test_auth.py
+++ b/cases/python/issue_test_mismatch_001/repo/tests/test_auth.py
@@ -1,0 +1,5 @@
+from auth import Token, login
+
+
+def test_valid_token():
+    assert login(Token(expired=False)) == 200

--- a/cases/python/mocked_core_path_001/claim.json
+++ b/cases/python/mocked_core_path_001/claim.json
@@ -1,0 +1,11 @@
+{
+  "claims": [
+    {
+      "id": "C1",
+      "text": "Payment retry logic stops after three attempts when the gateway keeps failing.",
+      "trigger": "gateway keeps failing",
+      "expected_outcome": "no more than three retry attempts",
+      "source": "issue.md"
+    }
+  ]
+}

--- a/cases/python/mocked_core_path_001/expected_findings.json
+++ b/cases/python/mocked_core_path_001/expected_findings.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "mocked_core_path_001",
+  "claims": [
+    {
+      "claim_id": "C1",
+      "adequacy": "weak",
+      "findings": [
+        {
+          "type": "Mocked Core Path",
+          "evidence_refs": [
+            "repo/tests/test_payment.py::test_process_payment_uses_retry"
+          ],
+          "rationale": "The test patches payment.retry_payment itself, replacing the function whose retry-limit behavior the claim requires the test to validate."
+        }
+      ]
+    }
+  ]
+}

--- a/cases/python/mocked_core_path_001/issue.md
+++ b/cases/python/mocked_core_path_001/issue.md
@@ -1,0 +1,3 @@
+# Payment retry limit
+
+Payment retry logic must stop after three attempts when the gateway keeps failing.

--- a/cases/python/mocked_core_path_001/metadata.json
+++ b/cases/python/mocked_core_path_001/metadata.json
@@ -1,0 +1,8 @@
+{
+  "language": "python",
+  "test_framework": "pytest",
+  "fixture_kind": "executable_micro_pr",
+  "ground_truth_source": "controlled_construction",
+  "case_id": "mocked_core_path_001",
+  "case_family": "Mocked Core Path"
+}

--- a/cases/python/mocked_core_path_001/pr.patch
+++ b/cases/python/mocked_core_path_001/pr.patch
@@ -1,0 +1,31 @@
+diff --git a/payment.py b/payment.py
+--- a/payment.py
++++ b/payment.py
+@@ -1,4 +1,4 @@
+-def retry_payment(gateway, max_attempts: int = 5) -> bool:
++def retry_payment(gateway, max_attempts: int = 3) -> bool:
+     for _ in range(max_attempts):
+         if gateway.charge():
+             return True
+diff --git a/tests/test_payment.py b/tests/test_payment.py
+--- a/tests/test_payment.py
++++ b/tests/test_payment.py
+@@ -1,3 +1,5 @@
++from unittest.mock import patch
++
+ from payment import process_payment
+ 
+ 
+@@ -8,3 +10,12 @@
+ 
+ def test_process_payment_success():
+     assert process_payment(Gateway()) is True
++
++
++def test_process_payment_uses_retry():
++    gateway = Gateway()
++    with patch("payment.retry_payment", return_value=False) as mocked_retry:
++        result = process_payment(gateway)
++
++    assert result is False
++    mocked_retry.assert_called_once_with(gateway)

--- a/cases/python/mocked_core_path_001/repo/payment.py
+++ b/cases/python/mocked_core_path_001/repo/payment.py
@@ -1,0 +1,9 @@
+def retry_payment(gateway, max_attempts: int = 5) -> bool:
+    for _ in range(max_attempts):
+        if gateway.charge():
+            return True
+    return False
+
+
+def process_payment(gateway) -> bool:
+    return retry_payment(gateway)

--- a/cases/python/mocked_core_path_001/repo/tests/test_payment.py
+++ b/cases/python/mocked_core_path_001/repo/tests/test_payment.py
@@ -1,0 +1,10 @@
+from payment import process_payment
+
+
+class Gateway:
+    def charge(self):
+        return True
+
+
+def test_process_payment_success():
+    assert process_payment(Gateway()) is True

--- a/cases/python/weak_assertion_001/claim.json
+++ b/cases/python/weak_assertion_001/claim.json
@@ -1,0 +1,11 @@
+{
+  "claims": [
+    {
+      "id": "C1",
+      "text": "Creating a user with an empty password returns HTTP 400.",
+      "trigger": "password is empty",
+      "expected_outcome": "HTTP status 400",
+      "source": "issue.md"
+    }
+  ]
+}

--- a/cases/python/weak_assertion_001/expected_findings.json
+++ b/cases/python/weak_assertion_001/expected_findings.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "weak_assertion_001",
+  "claims": [
+    {
+      "claim_id": "C1",
+      "adequacy": "weak",
+      "findings": [
+        {
+          "type": "Weak Assertion",
+          "evidence_refs": [
+            "repo/tests/test_auth.py::test_empty_password"
+          ],
+          "rationale": "The added test invokes the empty-password path but only checks that a response exists; it never constrains the required HTTP 400 outcome."
+        }
+      ]
+    }
+  ]
+}

--- a/cases/python/weak_assertion_001/issue.md
+++ b/cases/python/weak_assertion_001/issue.md
@@ -1,0 +1,3 @@
+# Empty-password validation
+
+Creating a user with an empty password must be rejected with HTTP 400. A valid password should continue to create the user successfully.

--- a/cases/python/weak_assertion_001/metadata.json
+++ b/cases/python/weak_assertion_001/metadata.json
@@ -1,0 +1,8 @@
+{
+  "language": "python",
+  "test_framework": "pytest",
+  "fixture_kind": "executable_micro_pr",
+  "ground_truth_source": "controlled_construction",
+  "case_id": "weak_assertion_001",
+  "case_family": "Weak Assertion"
+}

--- a/cases/python/weak_assertion_001/pr.patch
+++ b/cases/python/weak_assertion_001/pr.patch
@@ -1,0 +1,22 @@
+diff --git a/auth.py b/auth.py
+--- a/auth.py
++++ b/auth.py
+@@ -7,4 +7,6 @@
+ 
+ 
+ def create_user(password: str) -> Response:
++    if not password:
++        return Response(status_code=400)
+     return Response(status_code=201)
+diff --git a/tests/test_auth.py b/tests/test_auth.py
+--- a/tests/test_auth.py
++++ b/tests/test_auth.py
+@@ -4,3 +4,8 @@
+ def test_valid_password_creates_user():
+     response = create_user("secret")
+     assert response.status_code == 201
++
++
++def test_empty_password():
++    response = create_user("")
++    assert response is not None

--- a/cases/python/weak_assertion_001/repo/auth.py
+++ b/cases/python/weak_assertion_001/repo/auth.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Response:
+    status_code: int
+
+
+def create_user(password: str) -> Response:
+    return Response(status_code=201)

--- a/cases/python/weak_assertion_001/repo/tests/test_auth.py
+++ b/cases/python/weak_assertion_001/repo/tests/test_auth.py
@@ -1,0 +1,6 @@
+from auth import create_user
+
+
+def test_valid_password_creates_user():
+    response = create_user("secret")
+    assert response.status_code == 201

--- a/docs/annotation-guidelines.md
+++ b/docs/annotation-guidelines.md
@@ -1,0 +1,149 @@
+# Annotation Guidelines
+
+This document defines the initial human-labeling rules for Claim Harness curated cases.
+
+The goal is to keep expected findings independent from the implementation. A case should be labeled from the issue, claim, patch, tests, and controlled case construction before Claim Harness output is considered.
+
+## Annotation Unit
+
+The primary annotation unit is a **claim-evidence relationship**, not a whole pull request.
+
+Each claim should be reviewed against:
+
+- the behavior requested by the issue or task;
+- the code changed to implement that behavior;
+- the tests intended to support the claim;
+- the assertions those tests make;
+- whether mocks or patches replace the behavior under review;
+- optional execution evidence such as coverage, CI results, or counterfactual probes.
+
+## Labeling Principles
+
+1. Label the evidence, not the overall quality of the PR.
+2. Do not infer correctness from passing CI alone.
+3. Do not infer adequacy from changed-line coverage alone.
+4. Treat mocks as neutral until their relationship to the claim is established.
+5. Prefer observable or reproducible evidence over reviewer intuition.
+6. Mark ambiguous cases for adjudication instead of forcing a confident label.
+7. Do not use Claim Harness output when creating the ground-truth label.
+
+## Finding Rules
+
+### `Missing Test Evidence`
+
+Label `Missing Test Evidence` when all of the following hold:
+
+1. A concrete change claim can be identified.
+2. The patch changes behavior relevant to that claim.
+3. No added, modified, or existing test can be identified as meaningful evidence for the claimed behavior.
+
+A test for a nearby but materially different behavior does not remove this finding.
+
+### `Uncovered Changed Lines`
+
+Label `Uncovered Changed Lines` when:
+
+1. executable changed lines or branches are relevant to a claim; and
+2. execution evidence shows those lines or branches were not run by the relevant tests.
+
+This label requires runtime coverage evidence and is not expected in curated cases that do not yet include generated coverage data.
+
+### `Weak Assertion`
+
+Label `Weak Assertion` when:
+
+1. a claim has a plausible related test;
+2. the relevant changed behavior is exercised or intentionally represented by the test setup; and
+3. the assertions do not constrain the key outcome named by the claim.
+
+Examples include checking only that a response is non-null when the claim requires a specific HTTP status, exception, state transition, or side effect.
+
+A surviving counterfactual probe can strengthen this label but is not required for the initial curated cases.
+
+### `Issue-Test Mismatch`
+
+Label `Issue-Test Mismatch` when:
+
+1. the issue or structured claim requires behavior A; and
+2. the available test evidence primarily validates behavior B; and
+3. B can pass without establishing A.
+
+Typical examples include a failure-path claim paired only with a normal-path test, or a retry-limit claim paired only with a success-path test.
+
+### `Suspicious Fix Without Test`
+
+Label `Suspicious Fix Without Test` when a patch introduces or changes behavior and the submitted evidence surface contains no corresponding test change or identifiable existing test link.
+
+Use this as a review-risk label. It does not assert that the implementation is wrong.
+
+### `Mocked Core Path`
+
+Label `Mocked Core Path` when:
+
+1. the claim's core behavior can be localized to a function, method, component, or behavior path;
+2. the relevant test uses a mock, stub, patch, monkeypatch, or equivalent substitution; and
+3. that substitution replaces the behavior that the claim itself requires the test to validate.
+
+Do **not** label a mock merely because it appears in the test. Mocking an external dependency can be appropriate when the behavior under review is the caller's policy or orchestration.
+
+Example of acceptable isolation:
+
+```python
+gateway.charge = Mock(side_effect=TimeoutError)
+assert retry_manager.attempt_count == 3
+```
+
+if the claim is about retry behavior.
+
+Example of a mocked core path:
+
+```python
+retry_manager.retry = Mock(return_value=False)
+```
+
+if the claim is specifically that `retry_manager.retry` stops after three attempts.
+
+### `CI Scope Weakening`
+
+Label `CI Scope Weakening` when submitted CI or test configuration is changed in a way that excludes or skips validation relevant to the claim.
+
+Examples include:
+
+- adding a skip marker to the relevant test;
+- narrowing a test command so the affected package no longer runs;
+- excluding the changed path from coverage;
+- changing filters so the relevant job no longer executes.
+
+This label requires CI or configuration evidence.
+
+### `Counterfactual Survivor`
+
+Label `Counterfactual Survivor` only when a controlled probe has actually been executed.
+
+The label applies when:
+
+1. the probe removes, weakens, or reverses the behavior named in the claim;
+2. the mapped supporting tests are rerun; and
+3. those tests still pass.
+
+A reviewer prediction that a mutation "would probably survive" is not sufficient.
+
+### `Evidence Complete`
+
+Label `Evidence Complete` conservatively when the available evidence is relatively complete for the stated claim and none of the benchmark's targeted inadequacy findings apply.
+
+For the initial curated cases, this means the case intentionally includes a test whose setup and assertions directly constrain the claim and does not replace the core behavior with a mock.
+
+`Evidence Complete` does not mean the PR is correct, secure, performant, complete, or ready to merge.
+
+## Ambiguity and Adjudication
+
+For future real-world PRs:
+
+1. At least two reviewers should independently label each claim.
+2. Reviewers should not see Claim Harness output before labeling.
+3. Disagreements should be resolved by a third reviewer or explicit adjudication.
+4. Cases with unresolved ambiguity should be excluded from the primary benchmark score or reported separately.
+5. Inter-annotator agreement should be reported once the real-world set is large enough.
+
+The first curated cases are intentionally synthetic so the targeted evidence defect is controlled by construction.

--- a/docs/benchmark-protocol.md
+++ b/docs/benchmark-protocol.md
@@ -1,0 +1,152 @@
+# Benchmark Protocol
+
+This document defines the first comparison protocol for Claim Harness and simpler baselines.
+
+The benchmark is intended to answer a narrow question:
+
+> Given the same agentic-PR evidence surface, how accurately can a method identify whether test evidence supports each change claim?
+
+The benchmark does not score overall PR correctness.
+
+## Evaluation Unit
+
+The primary unit is one labeled claim inside one case.
+
+A case contains:
+
+- an issue or task;
+- one or more structured claims;
+- a small executable repository fixture;
+- a PR-like patch;
+- human-authored expected findings;
+- optional runtime artifacts added by later runner stages.
+
+## Ground Truth
+
+Ground truth must be defined independently from Claim Harness output.
+
+For synthetic curated cases, the target defect is controlled by construction and documented in `expected_findings.json`.
+
+For future real-world PRs, labels should follow `docs/annotation-guidelines.md`, use blind independent reviewers, and resolve disagreements through adjudication.
+
+## Baselines
+
+The initial benchmark should compare at least these perspectives.
+
+### Coverage Only
+
+Inputs:
+
+- changed lines or branches;
+- coverage evidence.
+
+This baseline can identify uncovered changed code but should not infer semantic adequacy.
+
+### Test-Diff Heuristic
+
+Inputs:
+
+- PR diff;
+- test diff.
+
+Possible signals include:
+
+- whether tests changed;
+- assertion shape;
+- skips;
+- mock additions;
+- fallback or exception-handling changes.
+
+The baseline should remain deterministic and intentionally simple.
+
+### LLM Prompt Only
+
+Inputs:
+
+- issue or task;
+- PR diff;
+- test diff.
+
+The model is prompted to identify evidence-adequacy findings without structured runtime evidence.
+
+### LLM All Evidence
+
+Once runtime artifacts exist, provide the LLM with the same available evidence surface used by Claim Harness:
+
+- issue and claims;
+- PR and test diffs;
+- coverage;
+- CI results;
+- mock summary;
+- counterfactual results when available.
+
+This baseline helps separate the value of **more evidence** from the value of Claim Harness's structured evidence chain.
+
+### Claim Harness
+
+Uses the structured claim-evidence workflow defined by the project methodology.
+
+## Output Contract for Comparison
+
+Each evaluated method should normalize its output to:
+
+```json
+{
+  "case_id": "weak_assertion_001",
+  "claim_id": "C1",
+  "findings": [
+    {
+      "type": "Weak Assertion",
+      "evidence_refs": []
+    }
+  ]
+}
+```
+
+Free-form explanations can be retained separately, but benchmark scoring should operate on normalized finding labels.
+
+## Primary Metrics
+
+Report:
+
+- precision;
+- recall;
+- F1;
+- per-finding precision, recall, and F1.
+
+Do not rely only on a single aggregate score.
+
+A method can be strong at `Uncovered Changed Lines` and weak at `Issue-Test Mismatch`; the benchmark should preserve that distinction.
+
+## Secondary Metrics
+
+Add these once implementations exist:
+
+- run-to-run consistency;
+- evidence-localization accuracy;
+- latency;
+- LLM token or API cost;
+- number of findings requiring human correction.
+
+## Ablations
+
+Once Claim Harness has multiple evidence layers, compare:
+
+- full Claim Harness;
+- without semantic reasoning;
+- without per-test coverage;
+- without mock-boundary analysis;
+- without counterfactual probes.
+
+The goal is to show which components materially improve which finding families.
+
+## Reporting Rules
+
+Benchmark reports should:
+
+1. distinguish synthetic and real-world results;
+2. report case counts by finding family;
+3. include confidence intervals when the sample size supports them;
+4. disclose model and prompt versions for LLM baselines;
+5. avoid claiming that benchmark success proves PR correctness;
+6. retain enough evidence references to audit false positives and false negatives.

--- a/docs/evaluation-design.md
+++ b/docs/evaluation-design.md
@@ -1,6 +1,6 @@
 # Evaluation Design
 
-This document defines how Claim Harness should be evaluated and reproduced once curated cases and a runner exist. It is not an implementation design, and it does not define a full benchmark suite yet.
+This document defines how Claim Harness should be evaluated and reproduced as curated cases and a runner are introduced.
 
 The goal is to keep Claim Harness centered on test evidence adequacy for agentic PRs, rather than drifting into a generic coverage wrapper.
 
@@ -12,7 +12,7 @@ Claim Harness evaluates test evidence adequacy. It does not prove that a PR is c
 
 ## Input Artifacts
 
-Future cases or runner executions should treat the PR and its review artifacts as the input surface:
+Future runner executions should treat the PR and its review artifacts as the input surface:
 
 - `issue.md` or task description: the source of the requested behavior or engineering change.
 - PR title and description: the author's stated change claims and rationale.
@@ -54,6 +54,8 @@ Claim Harness should be compared against simpler perspectives so the added value
 | Test Diff Heuristic | Whether tests were added or changed, whether assertions increased, and whether skips, mocks, or snapshots changed. | Can detect suspicious shape, but cannot reliably connect tests to claims or executed behavior. |
 | LLM Judge Only | Uses the issue, PR diff, and test diff to prompt an LLM for test sufficiency. | Useful as a prompt-only comparison, but too opaque to be the core method. |
 | Claim Harness Evidence Chain | Combines claim extraction, diff mapping, related tests, coverage, CI evidence, counterfactual probes, and mock boundary analysis. | More artifact-heavy, but produces findings tied to auditable evidence. |
+
+A later benchmark should also include an **LLM All Evidence** baseline that receives the same runtime evidence made available to Claim Harness. This helps distinguish the value of additional evidence from the value of structured evidence linking.
 
 Claim Harness does not reject coverage. Diff coverage should be both a baseline and an evidence source. The harness should find the review risks that coverage alone can miss, including `Weak Assertion`, `Issue-Test Mismatch`, `Mocked Core Path`, `Suspicious Fix Without Test`, and `Counterfactual Survivor`.
 
@@ -97,9 +99,9 @@ The submitted validation scope appears weaker than the PR's affected behavior re
 
 A counterfactual probe weakens, removes, or reverses the claimed behavior and the related tests still pass. This suggests the tests do not actually enforce the behavior named in the claim.
 
-## Case Design
+## Executable Case Contract
 
-Future benchmark-style cases should be small, explicit, and artifact-backed. A case should make it possible to reproduce the evidence chain and compare Claim Harness against simpler baselines.
+Initial benchmark-style cases are intentionally small executable micro-PRs.
 
 Example layout:
 
@@ -108,39 +110,57 @@ cases/
   python/
     weak_assertion_001/
       issue.md
-      pr.diff
-      test.diff
-      coverage.xml
-      ci.log
+      claim.json
       metadata.json
       expected_findings.json
+      pr.patch
+      repo/
+        auth.py
+        tests/
+          test_auth.py
 ```
 
 File roles:
 
 - `issue.md`: source material for the change claim.
-- `pr.diff`: code changes that implement or appear to implement the claim.
-- `test.diff`: added or modified tests and assertion changes.
-- `coverage.xml` or `lcov.info`: coverage evidence for changed code.
-- `ci.log`: evidence about which tests ran and whether they passed.
-- `metadata.json`: language, test framework, case family, task type, and other case-level labels.
-- `expected_findings.json`: human-labeled expected adequacy findings.
+- `claim.json`: manually structured claim or claims used to isolate evidence-adequacy evaluation from automatic claim extraction.
+- `metadata.json`: language, test framework, case family, fixture kind, and case-level labels.
+- `expected_findings.json`: human-authored ground truth created independently from Claim Harness output.
+- `pr.patch`: the PR-like change applied to the base fixture.
+- `repo/`: a minimal executable repository state before the PR patch is applied.
 
-The repository should not add real cases until the case format and expected finding shape are clear enough to review.
+The first cases use manual structured claims on purpose. Automatic natural-language claim extraction is a separate capability and should not be allowed to confound the first evidence-model evaluation.
 
-## Initial Curated Case Families
+## Initial Curated Cases
 
-The first curated cases should cover common ways an agentic PR can look tested while evidence remains inadequate:
+The first executable cases cover:
 
-- `weak_assertion_001`: changed code is executed by coverage, but the test only makes a weak assertion.
-- `missing_test_001`: core behavior changes without related test evidence.
-- `issue_test_mismatch_001`: the issue asks for a failure path, while the test covers only a normal path.
-- `mocked_core_path_001`: the test mocks out the path changed by the PR.
-- `fallback_without_test_001`: the PR adds fallback behavior, exception swallowing, or a default return without failure-path tests.
-- `ci_scope_weakening_001`: CI passes after the validation scope is narrowed or relevant tests are skipped.
-- `counterfactual_survivor_001`: removing or reversing the key fix still leaves the tests passing.
+- `weak_assertion_001`: changed behavior has a related test, but the assertion does not constrain the claim outcome.
+- `issue_test_mismatch_001`: the patch changes an expired-token path while the added test validates only the valid-token path.
+- `mocked_core_path_001`: the relevant test patches the function whose internal behavior is the subject of the claim.
+- `evidence_complete_001`: a positive control where the test directly constrains the stated status and state-change outcomes.
 
-These families should be intentionally small at first. The goal is to validate the evidence model before expanding coverage across languages, frameworks, or agent workflows.
+Later families can add:
+
+- missing test evidence;
+- fallback without failure-path testing;
+- CI scope weakening;
+- explicit counterfactual survivors;
+- uncovered changed branches.
+
+## Ground Truth
+
+Ground truth must be defined before system output is examined.
+
+For curated synthetic cases, the targeted defect is controlled by construction and documented in `expected_findings.json`.
+
+For future real-world agentic PRs:
+
+- use the rubric in `docs/annotation-guidelines.md`;
+- use blind independent reviewers;
+- adjudicate disagreements;
+- report inter-annotator agreement when sample size supports it;
+- exclude or separately report unresolved ambiguous cases.
 
 ## Expected Output
 
@@ -153,13 +173,16 @@ A future runner or case evaluator should emit artifacts that preserve the eviden
 - `mock_boundary_summary.json`: mocks, stubs, patches, and their relationship to the claimed behavior path.
 - `claim_harness_report.md`: human-readable review report summarizing claims, evidence, and findings.
 
-This document defines the intended output shape only. It does not require an implementation in this stage.
+The current curated-case validator only checks case structure and optional fixture executability. It is not the Claim Harness runner.
 
 ## Non-goals for This Stage
 
-- No runner implementation yet.
+- No Claim Harness runner yet.
 - No CLI yet.
-- No real curated cases yet.
+- No automatic claim extraction yet.
+- No LLM integration yet.
+- No automatic counterfactual generation yet.
+- No automatic mock-boundary classification yet.
 - No GitHub Action integration yet.
 - No claim that Claim Harness proves PR correctness.
 - No broad multi-language support yet.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,17 +1,22 @@
 # Roadmap and MVP Scope
 
-Claim Harness starts as a documentation and methodology seed. The first implementation should stay narrow: enough structure to evaluate a few real pull requests reproducibly, without turning into a general agent benchmark or a broad test-generation system.
+Claim Harness started as a documentation and methodology seed. The repository now adds a small executable benchmark foundation so later implementation can be evaluated against fixed cases and ground truth.
+
+The first implementation should stay narrow: enough structure to evaluate a few pull-request evidence patterns reproducibly, without turning into a general agent benchmark or a broad test-generation system.
 
 ## Current Scope
 
-This repository currently contains the initial documentation only:
+This repository now contains:
 
 - Project positioning and workflow in `README.md`.
 - Evaluation methodology in `docs/methodology.md`.
-- Evaluation design for future cases, baselines, findings, and outputs in `docs/evaluation-design.md`.
-- MVP boundary and staged roadmap in this document.
+- Evaluation design in `docs/evaluation-design.md`.
+- Human-labeling rules in `docs/annotation-guidelines.md`.
+- Baseline comparison rules in `docs/benchmark-protocol.md`.
+- Four executable Python/pytest micro-PR cases under `cases/python/`.
+- A lightweight structural and executability validator in `scripts/validate_cases.py`.
 
-There is no runner, CLI, benchmark case set, baseline comparison, or finding schema implementation yet.
+There is still no Claim Harness runner, automated semantic layer, per-test coverage mapping, automated mock analysis, counterfactual generator, or end-to-end baseline implementation.
 
 ## Ecosystem Position
 
@@ -28,13 +33,15 @@ The project should use restrained claims about novelty. The useful distinction i
 
 ## MVP Boundary
 
-The first practical MVP should aim for a small, inspectable workflow:
+The practical MVP should aim for a small, inspectable workflow:
 
 1. Curated Python/pytest cases with known weak and adequate evidence patterns.
 2. A minimal claim and finding format.
-3. A runner skeleton that can collect test output and coverage.
+3. A runner that can execute tests and collect coverage.
 4. Manual or semi-structured claim extraction before full automation.
-5. Baseline comparison against simple coverage-only rules.
+5. Baseline comparison against simple coverage-only and heuristic rules.
+6. A semantic layer only where natural-language alignment is required.
+7. Controlled mock-boundary and counterfactual analysis after the evidence chain is stable.
 
 The MVP should avoid:
 
@@ -43,33 +50,126 @@ The MVP should avoid:
 - Scoring PR correctness.
 - Treating an LLM judgment as the only evidence source.
 - Expanding into many languages before the evaluation shape is stable.
+- Emitting pseudo-precise confidence percentages before calibration data exists.
 
 ## Staged Evolution
 
-### Stage 1: Curated Cases
+### Stage 1: Curated Benchmark Foundation
 
-Add a small set of intentionally simple Python/pytest examples. Each case should follow the evaluation design in `docs/evaluation-design.md` and include a PR-like diff, an issue claim, test evidence, and expected findings such as `Weak Assertion`, `Mocked Core Path`, or `Evidence Complete`.
+**Status: initial version added.**
+
+Maintain a small set of executable Python/pytest examples. Each case includes:
+
+- an issue;
+- manually structured claims;
+- a base repository fixture;
+- a PR-like patch;
+- expected findings;
+- metadata.
+
+The first cases cover `Weak Assertion`, `Issue-Test Mismatch`, `Mocked Core Path`, and a positive `Evidence Complete` control.
+
+The stage also defines annotation and benchmark protocols so ground truth is fixed before the main implementation is evaluated.
 
 ### Stage 2: Runner Skeleton
 
-Add a lightweight runner that can execute tests, collect coverage, and emit raw artifacts. The runner should preserve evidence rather than immediately compressing it into a single score.
+Add a lightweight runner that can:
 
-### Stage 3: Findings Format
+- materialize or copy a case fixture;
+- apply its PR patch;
+- execute pytest;
+- collect raw test results;
+- collect line and branch coverage;
+- preserve raw artifacts rather than immediately compressing them into a score.
 
-Define a stable report shape that links each finding to claims, tests, coverage spans, probes, and CI evidence. The format should be easy to review in a PR comment or local artifact.
+### Stage 3: Per-Test Evidence Mapping
 
-### Stage 4: Counterfactual Probes
+Connect:
 
-Introduce controlled probes for selected cases. Early probes can be simple mutations that remove or weaken the claimed behavior, with clear limits and reproducibility notes.
+```text
+changed lines/functions -> exact pytest tests -> execution evidence
+```
 
-### Stage 5: Mock Boundary Analysis
+For the Python MVP, this stage can use diff parsing, Python AST information, pytest test IDs, and per-test coverage context.
 
-Add heuristics and language-specific analysis for identifying when mocks replace the core path under review. This should start with explicit patterns in curated cases before expanding.
+Emit the first machine-readable `evidence_chain.json`.
+
+### Stage 4: Initial Automated Findings
+
+Implement the first deterministic or mostly deterministic findings:
+
+- `Missing Test Evidence`;
+- `Uncovered Changed Lines`;
+- basic assertion extraction;
+- obvious weak-assertion patterns.
+
+Keep the rules auditable and report evidence references instead of a single opaque score.
+
+### Stage 5: Semantic Alignment
+
+Introduce an LLM-assisted semantic layer for tasks that genuinely require natural-language understanding:
+
+- issue or PR text to structured claims;
+- claim-to-code mapping where structural mapping is insufficient;
+- claim-to-assertion semantic alignment;
+- distinction between nearby but materially different test behavior.
+
+The LLM should propose or interpret semantics; structural and runtime artifacts remain the primary evidence.
+
+### Stage 6: Mock Boundary Analysis
+
+Start with explicit Python mock patterns:
+
+- `unittest.mock.patch`;
+- `pytest` monkeypatch;
+- common `mocker.patch` forms.
+
+First detect mock targets structurally. Then determine whether the mock merely isolates a dependency or replaces the behavior named by the claim.
+
+### Stage 7: Controlled Counterfactual Probes
+
+Introduce reproducible claim-guided probes.
+
+Progress from:
+
+1. manually authored counterfactual patches in curated cases;
+2. simple rule/AST-based mutations;
+3. optional LLM-guided mutation proposals validated and executed by the harness.
+
+A `Counterfactual Survivor` requires an actual rerun result, not an LLM prediction.
+
+### Stage 8: Baseline Benchmark
+
+Run the same labeled case suite through:
+
+- coverage only;
+- deterministic heuristic baseline;
+- LLM prompt-only baseline;
+- LLM all-evidence baseline;
+- Claim Harness.
+
+Report precision, recall, F1, and per-finding results. Add stability, cost, and evidence-localization metrics as the implementations mature.
+
+### Stage 9: Real-World Agentic PR Validation
+
+Expand beyond synthetic cases only after the evaluation contract is stable.
+
+Use:
+
+- real agent-generated PRs;
+- blind human labeling;
+- adjudication;
+- inter-annotator agreement;
+- a clearly separated real-world benchmark split.
 
 ## Design Principles
 
 - Evidence should be auditable by humans.
+- Ground truth should be independent from Claim Harness output.
 - Findings should explain why evidence is adequate or inadequate.
 - Coverage should remain an input, not the final answer.
+- LLM reasoning should handle semantics, not replace runtime evidence.
+- Mocks should be evaluated relative to the claim, not treated as inherently suspicious.
+- Counterfactual findings should be backed by executed probes.
 - Benchmarks should prefer small, clear cases before scale.
 - The harness should help reviewers find risk, not certify correctness.

--- a/scripts/validate_cases.py
+++ b/scripts/validate_cases.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Validate Claim Harness curated-case structure.
+
+By default this script checks file presence, JSON shape, claim references, and
+finding labels. With --run it also copies each fixture to a temporary directory,
+applies pr.patch with `git apply`, and runs pytest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REQUIRED_FILES = {
+    "issue.md",
+    "claim.json",
+    "metadata.json",
+    "expected_findings.json",
+    "pr.patch",
+}
+
+ALLOWED_FINDINGS = {
+    "Evidence Complete",
+    "Missing Test Evidence",
+    "Uncovered Changed Lines",
+    "Weak Assertion",
+    "Issue-Test Mismatch",
+    "Suspicious Fix Without Test",
+    "Mocked Core Path",
+    "CI Scope Weakening",
+    "Counterfactual Survivor",
+}
+
+
+def load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+
+
+def validate_case(case_dir: Path) -> list[str]:
+    errors: list[str] = []
+
+    missing = sorted(name for name in REQUIRED_FILES if not (case_dir / name).is_file())
+    if missing:
+        errors.append(f"missing required files: {', '.join(missing)}")
+
+    repo_dir = case_dir / "repo"
+    if not repo_dir.is_dir():
+        errors.append("missing repo/ fixture directory")
+
+    if errors:
+        return errors
+
+    claim_doc = load_json(case_dir / "claim.json")
+    metadata = load_json(case_dir / "metadata.json")
+    expected = load_json(case_dir / "expected_findings.json")
+
+    claims = claim_doc.get("claims")
+    if not isinstance(claims, list) or not claims:
+        errors.append("claim.json must contain a non-empty 'claims' list")
+        claim_ids = set()
+    else:
+        claim_ids = set()
+        for item in claims:
+            claim_id = item.get("id") if isinstance(item, dict) else None
+            if not claim_id:
+                errors.append("every claim must have a non-empty 'id'")
+                continue
+            if claim_id in claim_ids:
+                errors.append(f"duplicate claim id: {claim_id}")
+            claim_ids.add(claim_id)
+
+    if metadata.get("case_id") != case_dir.name:
+        errors.append(
+            f"metadata.json case_id must equal directory name {case_dir.name!r}"
+        )
+
+    expected_claims = expected.get("claims")
+    if not isinstance(expected_claims, list) or not expected_claims:
+        errors.append("expected_findings.json must contain a non-empty 'claims' list")
+    else:
+        for result in expected_claims:
+            claim_id = result.get("claim_id") if isinstance(result, dict) else None
+            if claim_id not in claim_ids:
+                errors.append(
+                    f"expected_findings.json references unknown claim_id {claim_id!r}"
+                )
+            findings = result.get("findings")
+            if not isinstance(findings, list) or not findings:
+                errors.append(
+                    f"claim {claim_id!r} must contain a non-empty findings list"
+                )
+                continue
+            for finding in findings:
+                finding_type = finding.get("type") if isinstance(finding, dict) else None
+                if finding_type not in ALLOWED_FINDINGS:
+                    errors.append(
+                        f"claim {claim_id!r} uses unknown finding type {finding_type!r}"
+                    )
+
+    return errors
+
+
+def run_case(case_dir: Path) -> tuple[bool, str]:
+    with tempfile.TemporaryDirectory(prefix=f"{case_dir.name}-") as temp:
+        temp_dir = Path(temp)
+        repo_copy = temp_dir / "repo"
+        shutil.copytree(case_dir / "repo", repo_copy)
+
+        patch_path = case_dir / "pr.patch"
+        apply_result = subprocess.run(
+            ["git", "apply", "--whitespace=nowarn", str(patch_path.resolve())],
+            cwd=repo_copy,
+            capture_output=True,
+            text=True,
+        )
+        if apply_result.returncode != 0:
+            return False, f"git apply failed:\n{apply_result.stderr.strip()}"
+
+        test_result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q"],
+            cwd=repo_copy,
+            capture_output=True,
+            text=True,
+        )
+        output = (test_result.stdout + "\n" + test_result.stderr).strip()
+        return test_result.returncode == 0, output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cases-root",
+        default="cases/python",
+        help="directory containing curated cases (default: cases/python)",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="apply each PR patch in a temp copy and run pytest",
+    )
+    args = parser.parse_args()
+
+    cases_root = Path(args.cases_root)
+    if not cases_root.is_dir():
+        print(f"ERROR: cases root not found: {cases_root}", file=sys.stderr)
+        return 1
+
+    case_dirs = sorted(path for path in cases_root.iterdir() if path.is_dir())
+    if not case_dirs:
+        print(f"ERROR: no cases found under {cases_root}", file=sys.stderr)
+        return 1
+
+    failed = False
+    for case_dir in case_dirs:
+        errors = validate_case(case_dir)
+        if errors:
+            failed = True
+            print(f"[FAIL] {case_dir.name}")
+            for error in errors:
+                print(f"  - {error}")
+            continue
+
+        print(f"[OK]   {case_dir.name}: structure")
+
+        if args.run:
+            ok, output = run_case(case_dir)
+            if ok:
+                print(f"[OK]   {case_dir.name}: patched fixture tests")
+            else:
+                failed = True
+                print(f"[FAIL] {case_dir.name}: patched fixture tests")
+                print(output)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add four executable Python/pytest micro-PR benchmark cases
- define claim-centered ground-truth annotation guidelines
- define baseline comparison and benchmark protocol
- add a lightweight case validator for structure and fixture executability
- update README, evaluation design, and roadmap for the benchmark-foundation stage

## Initial cases

- `weak_assertion_001`
- `issue_test_mismatch_001`
- `mocked_core_path_001`
- `evidence_complete_001`

Each case includes an issue, structured claim, base repository fixture, PR-like patch, metadata, and expected findings.

## Validation

- `python3 scripts/validate_cases.py`
- `python3 scripts/validate_cases.py --run`
- `git diff --check`

All four curated fixtures apply successfully and pass their patched pytest suites.

## Scope

This PR intentionally does not add:

- the Claim Harness runner
- automated claim extraction
- LLM integration
- automated mock-boundary classification
- counterfactual generation
- GitHub Action integration

The next stage is the runner skeleton for test execution and coverage evidence collection.