### PR TITLE
ci: validate curated benchmark cases

### DIFF
--- a/.github/workflows/benchmark-cases.yml
+++ b/.github/workflows/benchmark-cases.yml
@@ -1,0 +1,30 @@
+name: Benchmark Cases
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-cases:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Validate case structure
+        run: python scripts/validate_cases.py
+
+      - name: Run executable cases
+        run: python scripts/validate_cases.py --run


### PR DESCRIPTION
## Summary

- add GitHub Actions CI for curated benchmark cases
- validate case structure on pull requests and pushes to main
- execute patched Python/pytest fixtures in CI
- allow manual workflow runs with `workflow_dispatch`

## Validation

- `python3 scripts/validate_cases.py`
- `python3 scripts/validate_cases.py --run`
- `git diff --check`

This workflow validates the repository benchmark fixtures only. It does not add Claim Harness product-level GitHub Action integration.