### PR TITLE
runner: evaluate findings loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ python3 scripts/validate_cases.py --run
 
 The `--run` mode requires `git` and `pytest` in the local environment.
 
-Generate raw evidence artifacts for the curated cases:
+Generate evidence artifacts and v0 adequacy findings for the curated cases:
 
 ```bash
 python3 scripts/run_case.py
 ```
 
-The runner writes per-case artifacts under `artifacts/`, including test results, coverage evidence, test/assertion summaries, an evidence chain, expected findings, and a short Markdown report. It does not make automated adequacy findings yet.
+The runner writes per-case artifacts under `artifacts/`, including test results, coverage evidence, test/assertion summaries, mock-boundary summaries, limited counterfactual probe results, an evidence chain, generated findings, expected-finding comparison, and a short Markdown report.
 
 Validate real PR input bundles:
 
@@ -127,29 +127,28 @@ This optional script requires `requirements-llm.txt`. It emits candidate claims 
 - [Real PR Input Bundles](docs/real-pr-input.md): how real PR artifacts and LLM-assisted claim candidates should be organized.
 - [Annotation Guidelines](docs/annotation-guidelines.md): how human ground truth should be created without using Claim Harness output.
 - [Benchmark Protocol](docs/benchmark-protocol.md): how coverage, heuristic, LLM, and Claim Harness methods should be compared.
-- [Runner Artifacts](docs/runner-artifacts.md): what the first raw artifact runner emits for curated cases.
+- [Runner Artifacts](docs/runner-artifacts.md): what the curated-case runner emits for evidence, findings, mock boundaries, and probes.
 - [Roadmap](docs/roadmap.md): the MVP boundary and staged evolution.
 
 ## Current Scope
 
-This repository now contains documentation plus the first executable benchmark fixtures, a lightweight case validator, an evidence artifact runner, and a dogfood real PR input bundle.
+This repository now contains documentation plus the first executable benchmark fixtures, a lightweight case validator, a curated-case evidence runner with v0 deterministic findings, and a dogfood real PR input bundle.
 
 It still does **not** include:
 
-- a full Claim Harness adequacy runner;
-- automated adequacy findings;
+- a full general-purpose Claim Harness adequacy runner for arbitrary repositories;
 - default automated claim extraction;
 - automated real PR ingestion;
 - per-test coverage mapping;
 - automated LLM semantic reasoning;
-- automated mock-boundary classification;
-- counterfactual generation;
-- GitHub Action integration.
+- broad mock-boundary classification beyond explicit Python mock patterns;
+- broad counterfactual generation beyond limited deterministic probe templates;
+- a reusable GitHub Action for external PR review.
 
-The next implementation stage is a lightweight runner that can execute tests, collect coverage, and preserve raw evidence for later claim-centered analysis.
+The next implementation stage is to make the runner callable from other projects with a stable artifact contract and clearer packaging boundaries.
 
 ## Later Direction
 
-Future work can add the runner, stable finding schemas, baseline implementations, per-test coverage, semantic claim alignment, mock-boundary analysis, controlled counterfactual probes, and real-world agentic PR evaluation.
+Future work can add stable finding schemas, baseline implementations, per-test coverage, semantic claim alignment, broader mock-boundary analysis, broader controlled counterfactual probes, and real-world agentic PR evaluation.
 
 The goal is to make evidence-adequacy review repeatable without pretending that any automated harness can prove a PR correct.

--- a/cases/python/issue_test_mismatch_001/expected_findings.json
+++ b/cases/python/issue_test_mismatch_001/expected_findings.json
@@ -16,6 +16,20 @@
           "type": "Missing Test Evidence",
           "evidence_refs": [],
           "rationale": "No test in the submitted fixture checks the expired-token behavior required by the claim."
+        },
+        {
+          "type": "Uncovered Changed Lines",
+          "evidence_refs": [
+            "repo/auth.py:11"
+          ],
+          "rationale": "The expired-token branch introduced by the PR is not executed by the patched test run."
+        },
+        {
+          "type": "Counterfactual Survivor",
+          "evidence_refs": [
+            "repo/auth.py:11"
+          ],
+          "rationale": "Weakening the expired-token return still passes because the tests only cover valid-token behavior."
         }
       ]
     }

--- a/cases/python/mocked_core_path_001/expected_findings.json
+++ b/cases/python/mocked_core_path_001/expected_findings.json
@@ -11,6 +11,13 @@
             "repo/tests/test_payment.py::test_process_payment_uses_retry"
           ],
           "rationale": "The test patches payment.retry_payment itself, replacing the function whose retry-limit behavior the claim requires the test to validate."
+        },
+        {
+          "type": "Counterfactual Survivor",
+          "evidence_refs": [
+            "repo/payment.py:1"
+          ],
+          "rationale": "Changing the retry limit back to the weaker value still passes because the new test mocks the retry function instead of exercising it."
         }
       ]
     }

--- a/cases/python/weak_assertion_001/expected_findings.json
+++ b/cases/python/weak_assertion_001/expected_findings.json
@@ -11,6 +11,13 @@
             "repo/tests/test_auth.py::test_empty_password"
           ],
           "rationale": "The added test invokes the empty-password path but only checks that a response exists; it never constrains the required HTTP 400 outcome."
+        },
+        {
+          "type": "Counterfactual Survivor",
+          "evidence_refs": [
+            "repo/auth.py:11"
+          ],
+          "rationale": "Weakening the new HTTP 400 response to a success response should still pass because the test only checks that a response object exists."
         }
       ]
     }

--- a/docs/evaluation-design.md
+++ b/docs/evaluation-design.md
@@ -173,16 +173,16 @@ A future runner or case evaluator should emit artifacts that preserve the eviden
 - `mock_boundary_summary.json`: mocks, stubs, patches, and their relationship to the claimed behavior path.
 - `claim_harness_report.md`: human-readable review report summarizing claims, evidence, and findings.
 
-The current curated-case validator only checks case structure and optional fixture executability. It is not the Claim Harness runner.
+The current curated-case runner emits this initial output shape for Python/pytest cases. It remains intentionally narrow and should be treated as a reproducible benchmark loop, not a general repository evaluator.
 
 ## Non-goals for This Stage
 
-- No Claim Harness runner yet.
+- No general-purpose Claim Harness runner for arbitrary repositories yet.
 - No CLI yet.
 - No automatic claim extraction yet.
 - No LLM integration yet.
-- No automatic counterfactual generation yet.
-- No automatic mock-boundary classification yet.
-- No GitHub Action integration yet.
+- No broad automatic counterfactual generation beyond limited deterministic templates.
+- No broad automatic mock-boundary classification beyond explicit Python mock targets.
+- No reusable GitHub Action for external PR review yet.
 - No claim that Claim Harness proves PR correctness.
 - No broad multi-language support yet.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,11 +16,11 @@ This repository now contains:
 - Real PR input rules in `docs/real-pr-input.md`.
 - Four executable Python/pytest micro-PR cases under `cases/python/`.
 - A lightweight structural and executability validator in `scripts/validate_cases.py`.
-- An evidence artifact runner in `scripts/run_case.py`.
+- A curated-case runner in `scripts/run_case.py` that emits evidence artifacts, v0 findings, mock-boundary summaries, limited counterfactual probe results, and expected-label comparisons.
 - Optional LLM-assisted claim candidate extraction in `scripts/extract_claim_candidates.py`.
 - A dogfood real PR input bundle under `examples/real-pr-bundles/`.
 
-There is still no automated adequacy finding engine, automated real PR ingestion client, per-test coverage mapping, automated mock analysis, counterfactual generator, or end-to-end baseline implementation.
+There is still no general-purpose adequacy runner for arbitrary repositories, automated real PR ingestion client, per-test coverage mapping, broad semantic alignment, broad mock analysis, broad counterfactual generator, or end-to-end baseline implementation.
 
 ## Ecosystem Position
 
@@ -77,7 +77,7 @@ The stage also defines annotation and benchmark protocols so ground truth is fix
 
 ### Stage 2: Runner Skeleton
 
-**Status: evidence artifact runner added.**
+**Status: evidence and v0 findings runner added.**
 
 Maintain a lightweight runner that can:
 
@@ -86,9 +86,11 @@ Maintain a lightweight runner that can:
 - execute pytest;
 - collect raw test results;
 - collect line coverage for changed code;
-- preserve raw artifacts rather than immediately compressing them into a score.
+- preserve raw artifacts rather than immediately compressing them into a score;
+- emit deterministic v0 findings for the initial curated case families;
+- compare generated labels with expected labels.
 
-The runner emits test results, coverage XML, a changed-line coverage map, test/assertion summaries, and an evidence chain. Per-test coverage remains a follow-up.
+The runner emits test results, coverage XML, a changed-line coverage map, test/assertion summaries, mock-boundary summaries, limited counterfactual probe results, an evidence chain, generated findings, expected-label comparison, and a Markdown report. Per-test coverage remains a follow-up.
 
 ### Stage 3: Real PR Input Bundles
 
@@ -121,12 +123,16 @@ Emit the first machine-readable `evidence_chain.json`.
 
 ### Stage 5: Initial Automated Findings
 
-Implement the first deterministic or mostly deterministic findings:
+**Status: v0 deterministic findings added for curated cases.**
+
+Maintain and improve the first deterministic or mostly deterministic findings:
 
 - `Missing Test Evidence`;
 - `Uncovered Changed Lines`;
 - basic assertion extraction;
-- obvious weak-assertion patterns.
+- obvious weak-assertion patterns;
+- explicit Python mock-boundary candidates;
+- limited counterfactual survivors.
 
 Keep the rules auditable and report evidence references instead of a single opaque score.
 
@@ -143,22 +149,26 @@ The LLM should propose or interpret semantics; structural and runtime artifacts 
 
 ### Stage 7: Mock Boundary Analysis
 
-Start with explicit Python mock patterns:
+**Status: explicit Python mock target detection added for curated cases.**
+
+Continue from explicit Python mock patterns:
 
 - `unittest.mock.patch`;
 - `pytest` monkeypatch;
 - common `mocker.patch` forms.
 
-First detect mock targets structurally. Then determine whether the mock merely isolates a dependency or replaces the behavior named by the claim.
+The first version detects mock targets structurally and marks targets that match changed functions or classes. The next step is better claim-relative classification: determine whether the mock merely isolates a dependency or replaces the behavior named by the claim.
 
 ### Stage 8: Controlled Counterfactual Probes
 
-Introduce reproducible claim-guided probes.
+**Status: limited deterministic probe templates added for curated cases.**
+
+Continue improving reproducible claim-guided probes.
 
 Progress from:
 
-1. manually authored counterfactual patches in curated cases;
-2. simple rule/AST-based mutations;
+1. simple rule/AST-based mutations;
+2. manually reviewed counterfactual patches in curated cases;
 3. optional LLM-guided mutation proposals validated and executed by the harness.
 
 A `Counterfactual Survivor` requires an actual rerun result, not an LLM prediction.

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -1,16 +1,16 @@
 # Runner Artifacts
 
-This document describes the first evidence artifact runner for curated Claim Harness cases. The runner is not the full evidence-adequacy engine. It prepares the inputs that later stages can use for semantic alignment, mock-boundary analysis, counterfactual probes, and baseline comparison.
+This document describes the curated-case runner for Claim Harness. The runner is not a full general-purpose evidence-adequacy engine, but it now executes the first closed loop for benchmark cases: collect evidence, run limited probes, inspect explicit mock boundaries, emit v0 findings, and compare them with expected labels.
 
 ## Purpose
 
-The curated cases already define issues, structured claims, PR-like patches, executable fixtures, metadata, and expected findings. The runner adds a reproducible execution layer:
+The curated cases already define issues, structured claims, PR-like patches, executable fixtures, metadata, and expected findings. The runner adds a reproducible evaluation layer:
 
 ```text
-case fixture -> patched working copy -> pytest + coverage -> evidence artifacts
+case fixture -> patched working copy -> pytest + coverage -> mock/probe checks -> findings
 ```
 
-The first version deliberately stops before automated adequacy judgment. It should preserve evidence, not collapse the case into a single score.
+The runner preserves evidence instead of collapsing the case into a single score. Its findings are deterministic review-support signals for curated Python/pytest cases, not proof that a PR is correct.
 
 ## Command
 
@@ -50,7 +50,11 @@ artifacts/
     coverage_map.json
     test_diff_summary.json
     assertion_summary.json
+    mock_boundary_summary.json
+    counterfactual_results.json
     evidence_chain.json
+    findings.json
+    comparison_summary.json
     expected_findings.json
     claim_harness_report.md
 ```
@@ -79,9 +83,39 @@ Lists discovered pytest test functions in changed test files.
 
 Lists Python `assert` statements in changed test files and records a simple assertion shape such as comparison, truthiness check, or existence check.
 
+### `mock_boundary_summary.json`
+
+Lists explicit Python mock targets found in changed test files. The v0 detector recognizes common `unittest.mock.patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`-style calls, then marks mocks whose target matches a changed function or class as core-path candidates.
+
+Mocks are not treated as inherently bad. The suspicious case is when the mock replaces the same path the claim requires the test to validate.
+
+### `counterfactual_results.json`
+
+Records limited deterministic probes generated from changed code lines. The v0 probe templates weaken common behavior signals such as HTTP error returns, boolean returns, and simple retry limits, then rerun the patched pytest suite.
+
+A surviving probe means the weakened behavior still passed the tests. This can support a `Counterfactual Survivor` finding.
+
 ### `evidence_chain.json`
 
-Connects each structured claim to changed code files, changed code lines, related test files, test-result evidence, and coverage-map evidence. Automated adequacy findings are intentionally left empty in this version.
+Connects each structured claim to changed code files, changed code lines, related test files, test-result evidence, coverage-map evidence, mock-boundary evidence, counterfactual evidence, and generated adequacy findings.
+
+### `findings.json`
+
+Contains v0 generated findings by claim. The current deterministic rules cover:
+
+- `Evidence Complete`;
+- `Missing Test Evidence`;
+- `Uncovered Changed Lines`;
+- `Weak Assertion`;
+- `Issue-Test Mismatch`;
+- `Mocked Core Path`;
+- `Counterfactual Survivor`.
+
+The runner intentionally keeps the rationale and evidence references visible so reviewers can challenge the finding.
+
+### `comparison_summary.json`
+
+Compares generated finding labels with `expected_findings.json` for each claim. It reports exact label matches, missing expected labels, and extra generated labels. This artifact supports benchmark iteration; it does not fail the run by itself.
 
 ### `expected_findings.json`
 
@@ -95,11 +129,11 @@ Provides a small human-readable report for the case. It summarizes the claims an
 
 This runner does not:
 
-- produce `findings.json`;
-- infer claim adequacy;
+- evaluate arbitrary external repositories safely;
 - call an LLM;
-- classify mock boundaries;
-- generate counterfactual probes;
-- score baselines.
+- perform per-test coverage mapping;
+- run broad semantic claim alignment;
+- classify CI scope weakening from real CI configuration;
+- score baselines end to end.
 
-Those stages should build on the raw artifacts rather than replace them.
+Those stages should build on these artifacts rather than replace them.

--- a/scripts/run_case.py
+++ b/scripts/run_case.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Run curated Claim Harness cases and emit raw evidence artifacts.
+"""Run curated Claim Harness cases and emit evidence adequacy artifacts.
 
-This is intentionally a small artifact runner, not the full Claim Harness
-evaluation engine. It applies each case patch, runs the patched pytest fixture,
-and writes reviewable JSON/Markdown outputs for later evidence-chain work.
+This is intentionally a small runner, not a general repository evaluator. It
+applies each case patch, runs the patched pytest fixture, maps coverage, checks
+obvious assertion and mock-boundary signals, runs limited counterfactual probes,
+and writes reviewable JSON/Markdown outputs.
 """
 
 from __future__ import annotations
@@ -23,7 +24,26 @@ from typing import Any
 from validate_cases import validate_case
 
 
-RUNNER_VERSION = "0.2"
+RUNNER_VERSION = "0.3"
+
+WEAK_ASSERTION_SHAPES = {
+    "existence_or_none_check",
+    "truthiness_check",
+    "call_truthiness_check",
+}
+
+PROBE_REPLACEMENTS = [
+    ("status_code=400", "status_code=201", "weaken HTTP 400 response to success"),
+    ("status_code = 400", "status_code = 201", "weaken HTTP 400 response to success"),
+    ("return 400", "return 201", "weaken HTTP 400 return to success"),
+    ("return 401", "return 200", "weaken HTTP 401 return to success"),
+    ("status_code=401", "status_code=200", "weaken HTTP 401 response to success"),
+    ("status_code = 401", "status_code = 200", "weaken HTTP 401 response to success"),
+    ("return False", "return True", "flip false return"),
+    ("return True", "return False", "flip true return"),
+    ("max_attempts: int = 3", "max_attempts: int = 5", "weaken retry limit"),
+    ("max_attempts=3", "max_attempts=5", "weaken retry limit"),
+]
 
 
 def load_json(path: Path) -> Any:
@@ -104,6 +124,12 @@ def run_command(command: list[str], cwd: Path) -> dict[str, Any]:
         "stdout": result.stdout,
         "stderr": result.stderr,
     }
+
+
+def clear_python_bytecode(root: Path) -> None:
+    for cache_dir in root.rglob("__pycache__"):
+        if cache_dir.is_dir():
+            shutil.rmtree(cache_dir)
 
 
 def coverage_command(repo_copy: Path, coverage_xml_path: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
@@ -196,6 +222,31 @@ def source_for_node(source: str, node: ast.AST) -> str:
     return (ast.get_source_segment(source, node) or "").strip()
 
 
+def dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Call):
+        return dotted_name(node.func)
+    return None
+
+
+def token_set(*values: str | None) -> set[str]:
+    tokens: set[str] = set()
+    for value in values:
+        if not value:
+            continue
+        normalized = value.lower().replace("_", " ")
+        tokens.update(re.findall(r"[a-zA-Z0-9]+", normalized))
+    return {token for token in tokens if len(token) > 1}
+
+
 def summarize_assertions(repo_copy: Path, test_files: list[str]) -> dict[str, Any]:
     files = []
     total_assertions = 0
@@ -266,6 +317,461 @@ def summarize_tests(repo_copy: Path, test_files: list[str]) -> dict[str, Any]:
     }
 
 
+def collect_changed_symbols(
+    repo_copy: Path,
+    changed_code_files: list[str],
+    changed_code_lines: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+
+    for rel_path in changed_code_files:
+        path = repo_copy / rel_path
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        changed_lines = {item["line"] for item in changed_code_lines.get(rel_path, [])}
+        if not changed_lines:
+            continue
+
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        module_name = path.with_suffix("").name
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            start = getattr(node, "lineno", None)
+            end = getattr(node, "end_lineno", start)
+            if start is None or end is None:
+                continue
+            if not any(start <= line <= end for line in changed_lines):
+                continue
+            symbols.append(
+                {
+                    "file": rel_path,
+                    "name": node.name,
+                    "kind": type(node).__name__,
+                    "line_start": start,
+                    "line_end": end,
+                    "candidate_targets": sorted(
+                        {
+                            node.name,
+                            f"{module_name}.{node.name}",
+                            f"{rel_path.removesuffix('.py').replace('/', '.')}.{node.name}",
+                        }
+                    ),
+                }
+            )
+
+    return symbols
+
+
+def extract_mock_target(source: str, node: ast.Call) -> tuple[str | None, str | None]:
+    name = call_name(node)
+    if not name:
+        return None, None
+
+    if name.endswith("patch.object") and len(node.args) >= 2:
+        attr = node.args[1]
+        if isinstance(attr, ast.Constant) and isinstance(attr.value, str):
+            return f"{source_for_node(source, node.args[0])}.{attr.value}", "patch.object"
+
+    if name == "patch" or name.endswith(".patch"):
+        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            return node.args[0].value, "patch"
+
+    if name.endswith(".setattr") and len(node.args) >= 2:
+        if isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            return node.args[0].value, "setattr"
+        if isinstance(node.args[1], ast.Constant) and isinstance(node.args[1].value, str):
+            return f"{source_for_node(source, node.args[0])}.{node.args[1].value}", "setattr"
+
+    return None, None
+
+
+def mock_matches_changed_symbol(target: str, symbol: dict[str, Any]) -> bool:
+    normalized = target.strip("'\"")
+    for candidate in symbol["candidate_targets"]:
+        if normalized == candidate or normalized.endswith(f".{candidate}") or candidate.endswith(f".{normalized}"):
+            return True
+    return False
+
+
+def summarize_mock_boundaries(
+    repo_copy: Path,
+    test_files: list[str],
+    changed_symbols: list[dict[str, Any]],
+) -> dict[str, Any]:
+    mocks: list[dict[str, Any]] = []
+
+    for rel_path in test_files:
+        path = repo_copy / rel_path
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        for test_node in ast.walk(tree):
+            if not isinstance(test_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not test_node.name.startswith("test_"):
+                continue
+
+            call_nodes = [
+                node for node in ast.walk(test_node) if isinstance(node, ast.Call)
+            ]
+            call_nodes.extend(
+                node for node in test_node.decorator_list if isinstance(node, ast.Call)
+            )
+            for call in call_nodes:
+                target, style = extract_mock_target(source, call)
+                if not target or not style:
+                    continue
+                matched_symbols = [
+                    symbol
+                    for symbol in changed_symbols
+                    if mock_matches_changed_symbol(target, symbol)
+                ]
+                mocks.append(
+                    {
+                        "file": rel_path,
+                        "line": call.lineno,
+                        "test": test_node.name,
+                        "style": style,
+                        "target": target,
+                        "source": source_for_node(source, call),
+                        "is_core_path_candidate": bool(matched_symbols),
+                        "matched_changed_symbols": matched_symbols,
+                    }
+                )
+
+    return {
+        "runner_version": RUNNER_VERSION,
+        "summary": {
+            "mock_count": len(mocks),
+            "core_path_candidate_count": sum(
+                1 for item in mocks if item["is_core_path_candidate"]
+            ),
+        },
+        "changed_symbols": changed_symbols,
+        "mocks": sorted(mocks, key=lambda item: (item["file"], item["line"], item["target"])),
+    }
+
+
+def generate_counterfactual_probes(
+    changed_code_lines: dict[str, list[dict[str, Any]]],
+    max_probes: int = 5,
+) -> list[dict[str, Any]]:
+    probes: list[dict[str, Any]] = []
+    for rel_path, lines in changed_code_lines.items():
+        for item in lines:
+            content = item["content"]
+            for original, replacement, rationale in PROBE_REPLACEMENTS:
+                if original not in content:
+                    continue
+                probes.append(
+                    {
+                        "id": f"P{len(probes) + 1}",
+                        "file": rel_path,
+                        "line": item["line"],
+                        "original": original,
+                        "replacement": replacement,
+                        "rationale": rationale,
+                    }
+                )
+                break
+            if len(probes) >= max_probes:
+                return probes
+    return probes
+
+
+def run_counterfactual_probes(
+    repo_copy: Path,
+    changed_code_lines: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    probes = generate_counterfactual_probes(changed_code_lines)
+    results: list[dict[str, Any]] = []
+
+    for probe in probes:
+        path = repo_copy / probe["file"]
+        if not path.is_file():
+            results.append({**probe, "applied": False, "survived": None, "error": "file not found"})
+            continue
+
+        original_text = path.read_text(encoding="utf-8")
+        lines = original_text.splitlines(keepends=True)
+        index = probe["line"] - 1
+        if index < 0 or index >= len(lines) or probe["original"] not in lines[index]:
+            results.append(
+                {
+                    **probe,
+                    "applied": False,
+                    "survived": None,
+                    "error": "expected source fragment not found at changed line",
+                }
+            )
+            continue
+
+        lines[index] = lines[index].replace(probe["original"], probe["replacement"], 1)
+        path.write_text("".join(lines), encoding="utf-8")
+        clear_python_bytecode(repo_copy)
+        test_result = run_command([sys.executable, "-m", "pytest", "-q"], repo_copy)
+        path.write_text(original_text, encoding="utf-8")
+        clear_python_bytecode(repo_copy)
+
+        results.append(
+            {
+                **probe,
+                "applied": True,
+                "survived": bool(test_result["passed"]),
+                "test_result": {
+                    "command": test_result["command"],
+                    "returncode": test_result["returncode"],
+                    "passed": test_result["passed"],
+                    "stdout": test_result["stdout"],
+                    "stderr": test_result["stderr"],
+                },
+            }
+        )
+
+    return {
+        "runner_version": RUNNER_VERSION,
+        "summary": {
+            "probes_generated": len(probes),
+            "probes_applied": sum(1 for item in results if item["applied"]),
+            "survivors": sum(1 for item in results if item.get("survived") is True),
+        },
+        "probes": results,
+    }
+
+
+def flatten_assertions(assertion_summary: dict[str, Any]) -> list[dict[str, Any]]:
+    assertions: list[dict[str, Any]] = []
+    for file_item in assertion_summary.get("files", []):
+        for assertion in file_item.get("assertions", []):
+            assertions.append({**assertion, "file": file_item.get("path")})
+    return assertions
+
+
+def flatten_tests(test_summary: dict[str, Any]) -> list[dict[str, Any]]:
+    tests: list[dict[str, Any]] = []
+    for file_item in test_summary.get("files", []):
+        for test in file_item.get("tests", []):
+            tests.append({**test, "file": file_item.get("path")})
+    return tests
+
+
+def claim_expected_numbers(claim: dict[str, Any]) -> set[str]:
+    return set(
+        re.findall(
+            r"\b\d{3}\b",
+            " ".join(
+                str(claim.get(key, ""))
+                for key in ("text", "trigger", "expected_outcome")
+            ),
+        )
+    )
+
+
+def has_issue_test_mismatch(claim: dict[str, Any], assertions: list[dict[str, Any]], tests: list[dict[str, Any]]) -> bool:
+    evidence_text = " ".join(
+        [item.get("source", "") for item in assertions]
+        + [item.get("name", "") for item in tests]
+    ).lower()
+    trigger = str(claim.get("trigger", "")).lower()
+
+    if "expired" in trigger and "expired=true" not in evidence_text.replace(" ", ""):
+        return True
+
+    expected_numbers = claim_expected_numbers(claim)
+    if expected_numbers:
+        assertion_text = " ".join(item.get("source", "") for item in assertions)
+        has_expected_number = any(number in assertion_text for number in expected_numbers)
+        trigger_tokens = token_set(claim.get("trigger")) - {"is", "the", "a", "an", "with"}
+        evidence_tokens = token_set(evidence_text)
+        has_trigger_overlap = bool(trigger_tokens & evidence_tokens)
+        return not has_expected_number and not has_trigger_overlap
+
+    return False
+
+
+def finding(
+    finding_type: str,
+    evidence_refs: list[str],
+    rationale: str,
+) -> dict[str, Any]:
+    return {
+        "type": finding_type,
+        "evidence_refs": sorted(set(evidence_refs)),
+        "rationale": rationale,
+    }
+
+
+def build_findings(
+    case_id: str,
+    claim_doc: dict[str, Any],
+    test_result: dict[str, Any],
+    coverage_map: dict[str, Any],
+    test_summary: dict[str, Any],
+    assertion_summary: dict[str, Any],
+    mock_summary: dict[str, Any],
+    counterfactual_results: dict[str, Any],
+) -> dict[str, Any]:
+    assertions = flatten_assertions(assertion_summary)
+    tests = flatten_tests(test_summary)
+    test_refs = [f"repo/{item['file']}::{item['name']}" for item in tests]
+    weak_assertion_refs = [
+        f"repo/{item['file']}:{item['line']}"
+        for item in assertions
+        if item.get("shape") in WEAK_ASSERTION_SHAPES
+    ]
+    coverage_refs = [
+        f"repo/{file_item['path']}:{line_item['line']}"
+        for file_item in coverage_map.get("files", [])
+        for line_item in file_item.get("changed_lines", [])
+        if not line_item.get("covered")
+    ]
+    mock_refs = [
+        f"repo/{item['file']}:{item['line']}"
+        for item in mock_summary.get("mocks", [])
+        if item.get("is_core_path_candidate")
+    ]
+    survivor_refs = [
+        f"{item['id']}:{item['file']}:{item['line']}"
+        for item in counterfactual_results.get("probes", [])
+        if item.get("survived") is True
+    ]
+
+    claim_results = []
+    for claim in claim_doc.get("claims", []):
+        claim_findings: list[dict[str, Any]] = []
+        mismatch = has_issue_test_mismatch(claim, assertions, tests)
+
+        if not tests or not assertions:
+            claim_findings.append(
+                finding(
+                    "Missing Test Evidence",
+                    [],
+                    "No changed test function and assertion evidence was found for this claim.",
+                )
+            )
+
+        if coverage_refs:
+            claim_findings.append(
+                finding(
+                    "Uncovered Changed Lines",
+                    coverage_refs,
+                    "One or more changed executable lines were not covered by the patched test run.",
+                )
+            )
+
+        if mismatch:
+            claim_findings.append(
+                finding(
+                    "Issue-Test Mismatch",
+                    test_refs,
+                    "The discovered tests exercise a nearby path, but they do not constrain the trigger or outcome named by the claim.",
+                )
+            )
+            claim_findings.append(
+                finding(
+                    "Missing Test Evidence",
+                    test_refs,
+                    "The claim has tests in the PR, but no clear test evidence for the claimed behavior was found.",
+                )
+            )
+
+        if weak_assertion_refs and not mismatch:
+            claim_findings.append(
+                finding(
+                    "Weak Assertion",
+                    weak_assertion_refs,
+                    "At least one related test uses an assertion shape that exercises code without constraining the claimed outcome.",
+                )
+            )
+
+        if mock_refs:
+            claim_findings.append(
+                finding(
+                    "Mocked Core Path",
+                    mock_refs,
+                    "A test mock target matches a changed function or class, so the test may replace the path it should validate.",
+                )
+            )
+
+        if survivor_refs:
+            claim_findings.append(
+                finding(
+                    "Counterfactual Survivor",
+                    survivor_refs,
+                    "A generated counterfactual weakened changed behavior and the patched test suite still passed.",
+                )
+            )
+
+        if not claim_findings and test_result.get("passed"):
+            claim_findings.append(
+                finding(
+                    "Evidence Complete",
+                    test_refs,
+                    "The current evidence chain covers changed lines, includes constraining assertions, and has no v0 mock or probe warning. Human review is still required.",
+                )
+            )
+
+        adequacy = "complete" if all(item["type"] == "Evidence Complete" for item in claim_findings) else "weak"
+        claim_results.append(
+            {
+                "claim_id": claim.get("id"),
+                "adequacy": adequacy,
+                "findings": claim_findings,
+            }
+        )
+
+    return {
+        "case_id": case_id,
+        "runner_version": RUNNER_VERSION,
+        "claims": claim_results,
+    }
+
+
+def compare_findings(case_id: str, generated: dict[str, Any], expected: dict[str, Any]) -> dict[str, Any]:
+    expected_by_claim = {
+        item.get("claim_id"): sorted({finding.get("type") for finding in item.get("findings", [])})
+        for item in expected.get("claims", [])
+    }
+    generated_by_claim = {
+        item.get("claim_id"): sorted({finding.get("type") for finding in item.get("findings", [])})
+        for item in generated.get("claims", [])
+    }
+    claims = []
+    exact_matches = 0
+    for claim_id in sorted(set(expected_by_claim) | set(generated_by_claim)):
+        expected_labels = expected_by_claim.get(claim_id, [])
+        generated_labels = generated_by_claim.get(claim_id, [])
+        missing = sorted(set(expected_labels) - set(generated_labels))
+        extra = sorted(set(generated_labels) - set(expected_labels))
+        exact = not missing and not extra
+        exact_matches += int(exact)
+        claims.append(
+            {
+                "claim_id": claim_id,
+                "expected_labels": expected_labels,
+                "generated_labels": generated_labels,
+                "missing_expected_labels": missing,
+                "extra_generated_labels": extra,
+                "exact_label_match": exact,
+            }
+        )
+
+    return {
+        "case_id": case_id,
+        "runner_version": RUNNER_VERSION,
+        "summary": {
+            "claims_compared": len(claims),
+            "exact_label_matches": exact_matches,
+            "exact_label_match": exact_matches == len(claims),
+        },
+        "claims": claims,
+    }
+
+
 def run_case(case_dir: Path, output_root: Path) -> bool:
     errors = validate_case(case_dir)
     case_output = output_root / case_dir.name
@@ -306,10 +812,24 @@ def run_case(case_dir: Path, output_root: Path) -> bool:
         coverage_xml_result = None
         test_summary = {"runner_version": RUNNER_VERSION, "summary": {"test_count": 0}, "files": []}
         assertion_summary = {"runner_version": RUNNER_VERSION, "summary": {"assertion_count": 0}, "files": []}
+        mock_summary = {
+            "runner_version": RUNNER_VERSION,
+            "summary": {"mock_count": 0, "core_path_candidate_count": 0},
+            "changed_symbols": [],
+            "mocks": [],
+        }
+        counterfactual_results = {
+            "runner_version": RUNNER_VERSION,
+            "summary": {"probes_generated": 0, "probes_applied": 0, "survivors": 0},
+            "probes": [],
+        }
         if apply_result["passed"]:
             test_result, coverage_xml_result = coverage_command(repo_copy, coverage_xml_path)
             test_summary = summarize_tests(repo_copy, test_files)
             assertion_summary = summarize_assertions(repo_copy, test_files)
+            changed_symbols = collect_changed_symbols(repo_copy, changed_code_files, changed_code_lines)
+            mock_summary = summarize_mock_boundaries(repo_copy, test_files, changed_symbols)
+            counterfactual_results = run_counterfactual_probes(repo_copy, changed_code_lines)
 
     write_json(case_output / "test_result.json", test_result or apply_result)
     if coverage_xml_result is not None:
@@ -317,12 +837,33 @@ def run_case(case_dir: Path, output_root: Path) -> bool:
     write_json(case_output / "expected_findings.json", expected_findings)
     write_json(case_output / "test_diff_summary.json", test_summary)
     write_json(case_output / "assertion_summary.json", assertion_summary)
+    write_json(case_output / "mock_boundary_summary.json", mock_summary)
+    write_json(case_output / "counterfactual_results.json", counterfactual_results)
 
     coverage_map = build_coverage_map(case_dir.name, changed_code_lines, case_output / "coverage.xml")
     write_json(case_output / "coverage_map.json", coverage_map)
+    active_test_result = test_result or apply_result
+    generated_findings = build_findings(
+        case_dir.name,
+        claim_doc,
+        active_test_result,
+        coverage_map,
+        test_summary,
+        assertion_summary,
+        mock_summary,
+        counterfactual_results,
+    )
+    write_json(case_output / "findings.json", generated_findings)
+    comparison_summary = compare_findings(case_dir.name, generated_findings, expected_findings)
+    write_json(case_output / "comparison_summary.json", comparison_summary)
 
     claim_rows = []
+    findings_by_claim = {
+        item.get("claim_id"): item
+        for item in generated_findings.get("claims", [])
+    }
     for claim in claim_doc.get("claims", []):
+        claim_finding = findings_by_claim.get(claim.get("id"), {})
         claim_rows.append(
             {
                 "claim_id": claim.get("id"),
@@ -334,7 +875,10 @@ def run_case(case_dir: Path, output_root: Path) -> bool:
                 "test_result": "test_result.json",
                 "coverage_evidence": "coverage_map.json",
                 "ci_evidence": "test_result.json",
-                "adequacy_finding": None,
+                "mock_boundary_evidence": "mock_boundary_summary.json",
+                "counterfactual_evidence": "counterfactual_results.json",
+                "adequacy_finding": claim_finding.get("adequacy"),
+                "findings": claim_finding.get("findings", []),
             }
         )
 
@@ -348,7 +892,7 @@ def run_case(case_dir: Path, output_root: Path) -> bool:
         },
     )
 
-    passed = bool((test_result or apply_result)["passed"])
+    passed = bool(active_test_result["passed"])
     write_json(
         case_output / "case_summary.json",
         {
@@ -370,7 +914,11 @@ def run_case(case_dir: Path, output_root: Path) -> bool:
                 "coverage_map.json",
                 "test_diff_summary.json",
                 "assertion_summary.json",
+                "mock_boundary_summary.json",
+                "counterfactual_results.json",
                 "evidence_chain.json",
+                "findings.json",
+                "comparison_summary.json",
                 "expected_findings.json",
                 "claim_harness_report.md",
             ],
@@ -384,6 +932,10 @@ def run_case(case_dir: Path, output_root: Path) -> bool:
         coverage_map,
         test_summary,
         assertion_summary,
+        mock_summary,
+        counterfactual_results,
+        generated_findings,
+        comparison_summary,
     )
     return passed
 
@@ -396,11 +948,15 @@ def write_report(
     coverage_map: dict[str, Any],
     test_summary: dict[str, Any],
     assertion_summary: dict[str, Any],
+    mock_summary: dict[str, Any],
+    counterfactual_results: dict[str, Any],
+    generated_findings: dict[str, Any],
+    comparison_summary: dict[str, Any],
 ) -> None:
     lines = [
         f"# Claim Harness Case Report: {case_id}",
         "",
-        "This report is generated by the raw artifact runner. It does not make automated adequacy findings yet.",
+        "This report is generated by the curated-case runner. Findings are review support signals, not proof that a PR is correct.",
         "",
         "## Test Result",
         "",
@@ -417,9 +973,46 @@ def write_report(
         f"- Test functions discovered: `{test_summary['summary']['test_count']}`",
         f"- Assertions discovered: `{assertion_summary['summary']['assertion_count']}`",
         "",
-        "## Claims",
+        "## Mock Boundary",
+        "",
+        f"- Mock targets discovered: `{mock_summary['summary']['mock_count']}`",
+        f"- Core-path mock candidates: `{mock_summary['summary']['core_path_candidate_count']}`",
+        "",
+        "## Counterfactual Probes",
+        "",
+        f"- Probes generated: `{counterfactual_results['summary']['probes_generated']}`",
+        f"- Probes applied: `{counterfactual_results['summary']['probes_applied']}`",
+        f"- Survivors: `{counterfactual_results['summary']['survivors']}`",
+        "",
+        "## Findings",
         "",
     ]
+
+    for claim_result in generated_findings.get("claims", []):
+        lines.append(f"### `{claim_result.get('claim_id')}`")
+        lines.append("")
+        lines.append(f"- Adequacy: `{claim_result.get('adequacy')}`")
+        for item in claim_result.get("findings", []):
+            refs = ", ".join(f"`{ref}`" for ref in item.get("evidence_refs", [])) or "`none`"
+            lines.append(f"- `{item.get('type')}`: {item.get('rationale')} Evidence: {refs}.")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Expected Comparison",
+            "",
+            f"- Exact label match: `{str(comparison_summary['summary']['exact_label_match']).lower()}`",
+            f"- Claims compared: `{comparison_summary['summary']['claims_compared']}`",
+            "",
+        ]
+    )
+
+    lines.extend(
+        [
+        "## Claims",
+        "",
+        ]
+    )
 
     for claim in claim_doc.get("claims", []):
         lines.append(f"- `{claim.get('id')}`: {claim.get('text')}")
@@ -435,7 +1028,11 @@ def write_report(
             "- `coverage_map.json`",
             "- `test_diff_summary.json`",
             "- `assertion_summary.json`",
+            "- `mock_boundary_summary.json`",
+            "- `counterfactual_results.json`",
             "- `evidence_chain.json`",
+            "- `findings.json`",
+            "- `comparison_summary.json`",
             "- `expected_findings.json`",
             "",
         ]


### PR DESCRIPTION
## Summary

Add the first closed findings loop for curated Claim Harness cases.

This PR adds:
- generated findings.json output from deterministic v0 rules
- mock_boundary_summary.json for explicit Python mock targets and core-path candidates
- counterfactual_results.json for limited deterministic probes and rerun outcomes
- comparison_summary.json for generated-vs-expected finding labels
- updated expected findings for probe-backed curated cases
- README and runner artifact documentation updates

## Scope

This keeps the implementation narrow to curated Python/pytest cases. It does not add a CLI, package entrypoint, arbitrary repository execution, broad semantic alignment, or LLM-based adequacy judgment.

## Validation

- python scripts/validate_cases.py
- python scripts/validate_cases.py --run
- python scripts/run_case.py --output-dir /tmp/claim-harness-pr1-artifacts
- python scripts/validate_real_pr_bundles.py
- python -m compileall scripts
- rg Chinese character scan across committed project files