### PR TITLE
Add real PR checks and reusable GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -21,7 +23,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install test dependencies
-        run: python -m pip install -e .
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run direct-check unit tests
+        run: python -m pytest -q tests
 
       - name: Validate regression fixtures
         run: python scripts/validate_cases.py
@@ -38,11 +43,10 @@ jobs:
       - name: Check module entrypoint
         run: python -m pr_test_guard --version
 
-      - name: Validate fixtures through module entrypoint
-        run: python -m pr_test_guard validate-cases
+      - name: Smoke-test direct PR check
+        run: python -m pr_test_guard check --base HEAD~1 --format json > /tmp/pr-test-guard-direct.json
 
-      - name: Generate artifacts through module entrypoint
-        run: python -m pr_test_guard run-cases --case weak_assertion_001 --output-dir /tmp/pr-test-guard-module-artifacts
-
-      - name: Validate real PR bundles through module entrypoint
-        run: python -m pr_test_guard validate-real-pr-bundles
+      - name: Smoke-test reusable Action
+        uses: ./
+        with:
+          base: HEAD~1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default product direction is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.1.0` keeps the existing executable regression-fixture runner while the direct PR-checking CLI and reusable GitHub Action are being built.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.1.0` adds direct real-PR analysis and ships the same analyzer as a reusable GitHub Action.
 
 | | |
 | --- | --- |
@@ -21,36 +21,79 @@ The project is CLI-first and designed to fit naturally into CI. Its default prod
 
 ## Quick Start
 
-Clone the repository and run the current Python/pytest regression fixtures. Version `0.1.0`
-is intended for source-tree use and is not published to PyPI yet:
+Install from the source tree while `0.1.0` is being prepared for release:
 
 ```bash
 python3 -m pip install -e .
-python3 -m pr_test_guard --version
-python3 -m pr_test_guard validate-cases
-python3 -m pr_test_guard validate-cases --run
-python3 -m pr_test_guard run-cases --output-dir /tmp/pr-test-guard-artifacts
 ```
 
-The same commands are available through the console script after editable install:
+Run the checker inside any Git repository that contains the PR branch you want to review:
 
 ```bash
-pr-test-guard validate-cases
-pr-test-guard run-cases --case weak_assertion_001 --output-dir /tmp/pr-test-guard-artifacts
+cd /path/to/your-project
+pr-test-guard check --base origin/main
 ```
 
-The script entrypoints remain supported:
+If the project already produces a `coverage.py` XML report, add it as another signal:
 
 ```bash
-python3 scripts/validate_cases.py
-python3 scripts/validate_cases.py --run
-python3 scripts/run_case.py --output-dir /tmp/pr-test-guard-artifacts
+pr-test-guard check --base origin/main --coverage coverage.xml
 ```
 
-Validate the synthetic normalized real-PR input bundle:
+For the optional deeper check, explicitly provide the project's test command. PR Test Guard creates an isolated Git worktree, runs the unmodified tests once, then applies at most a few bounded probes to changed Python lines:
 
 ```bash
-python3 -m pr_test_guard validate-real-pr-bundles
+pr-test-guard check \
+  --base origin/main \
+  --deep \
+  --test-command "pytest -q" \
+  --max-probes 3
+```
+
+Findings are advisory and a successful analysis exits `0` even when warnings are found. Operational errors such as an invalid base ref or malformed coverage file exit non-zero.
+
+To run the same analyzer automatically on pull requests, add a workflow such as:
+
+```yaml
+name: PR Test Guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pr-test-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: tigerless-labs/pr-test-guard@v0.1.0
+        with:
+          base: origin/${{ github.base_ref }}
+```
+
+Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
+
+```yaml
+      - uses: tigerless-labs/pr-test-guard@v0.1.0
+        with:
+          base: origin/${{ github.base_ref }}
+          coverage: coverage.xml
+          deep: "true"
+          test-command: pytest -q
+          max-probes: "3"
+```
+
+The existing regression-fixture commands remain available for development of PR Test Guard itself. Install the development extras first:
+
+```bash
+python3 -m pip install -e ".[dev]"
+pr-test-guard validate-cases --run
+pr-test-guard run-cases --output-dir /tmp/pr-test-guard-artifacts
 ```
 
 ## What It Evaluates
@@ -70,21 +113,18 @@ It currently models evidence that can help answer:
 - **Do mocks or patches appear to replace the behavior under review?**
 - **Can a limited counterfactual change survive the attached tests?**
 
-Initial finding types are kept from the original research prototype because they exercise useful PR-test failure modes:
+The direct `check` command currently emits six PR-scoped rule families:
 
-| Finding | Meaning |
+| Rule | Signal |
 | --- | --- |
-| `Missing Test Evidence` | No clear test evidence is attached to a behavior-changing PR path. |
-| `Uncovered Changed Lines` | Relevant changed executable code is not exercised by the available tests. |
-| `Weak Assertion` | Code is exercised, but the assertion may not meaningfully constrain the expected outcome. |
-| `Issue-Test Mismatch` | The available test appears to validate a materially different behavior from the change intent. |
-| `Suspicious Fix Without Test` | A behavioral change appears without a corresponding test change or identifiable existing test link. |
-| `Mocked Core Path` | A mock or stub appears to replace the behavior path that should provide evidence. |
-| `CI Scope Weakening` | CI or test configuration appears to narrow validation around affected behavior. |
-| `Counterfactual Survivor` | A limited controlled weakening still passes the attached tests. |
-| `Evidence Complete` | The current fixture has no targeted evidence gap; this is not a correctness certificate. |
+| `PTG001` | Production Python changed but the PR contains no test-file change. |
+| `PTG002` | A changed Python line is uncovered in the supplied coverage XML. |
+| `PTG003` | A newly added assertion has an obviously weak existence/truthiness shape. |
+| `PTG004` | A test was deleted, skipped/xfail-marked, or lost assertions. |
+| `PTG005` | A structural mock target overlaps a Python symbol changed by the PR. |
+| `PTG006` | An opt-in bounded targeted probe survives the configured tests. |
 
-These are review-oriented signals. Heuristic findings such as `Weak Assertion` or `Mocked Core Path` should be advisory by default rather than automatic reasons to block a merge.
+These are review-oriented signals. Heuristic findings such as `PTG003` and `PTG005` are advisory by default rather than automatic reasons to block a merge. The older fixture runner retains its research-prototype labels internally so existing regression cases keep working.
 
 ## Current Runner
 
@@ -121,36 +161,26 @@ artifacts/<case_id>/
 
 ## Real PR Bundles
 
-PR Test Guard is intended to move from controlled fixtures to real pull requests without tying the core analysis to one agent or hosting workflow.
-
-The current normalized input prototype is:
+Normal users no longer need to prepare a normalized bundle. The primary real-PR path is repository-native:
 
 ```text
-PR metadata + diff + test/CI artifacts -> normalized PR bundle -> rule evidence -> findings
+current Git repository + base ref + optional coverage/test command
+  -> pr-test-guard check
+  -> PR-scoped rule signals
+  -> text / JSON / GitHub Actions output
 ```
 
-A normalized bundle can include:
+The older normalized bundle under `examples/real-pr-bundles/` remains as a development fixture and compatibility prototype for richer CI artifacts. It can include PR metadata, a diff, CI/test results, coverage, and optional change-intent context, but it is not required by the direct checker. See [Real PR Input](docs/real-pr-input.md).
 
-- `issue.md` or `task.md`
-- `pr.json`
-- `pr.diff`
-- `ci-summary.md`
-- `test-result.json` or `ci.log`
-- `coverage.xml` or `lcov.info`
-- optional change-intent candidates
-- `missing_artifacts.json`
-
-Missing artifacts should be recorded explicitly instead of silently treated as evidence. See [Real PR Input](docs/real-pr-input.md).
-
-The long-term integration is intentionally lighter than a hosted service: keep the analysis core callable from the CLI, then wrap it in a GitHub Action so pull requests can receive automatic advisory results in CI.
+The reusable `action.yml` calls the same CLI/core. There is no separate hosted analysis service and no API key is required for the default path.
 
 ## Mock and Probe Boundaries
 
 The current mock detector is structural. It recognizes explicit Python patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, then checks whether the target matches a changed function or class. That produces a **candidate signal**; it does not prove that the mock is wrong.
 
-The current counterfactual probe generator is also deliberately limited. It covers common status-code weakening, boolean return flips, simple retry-limit rollback, and basic inclusive-boundary comparison weakening. A `Counterfactual Survivor` requires an actual pytest rerun result.
+The targeted probe generator is deliberately limited. It covers a small set of status-code changes, boolean return flips, and comparison-boundary changes on lines added by the current PR. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
 
-These deeper signals are retained from the original prototype, but they are not required to define the product. The lightweight public direction is to keep deterministic rules understandable, cheap to run, and safe to treat as advisory unless a repository explicitly opts into enforcement.
+These deeper signals are part of the product's differentiation beyond patch coverage. Mock-boundary analysis stays static and advisory. Targeted probes are bounded, PR-scoped, and opt-in through `--deep` because they rerun repository tests. The goal is not a full mutation-testing campaign; it is a small number of review-focused probes against code changed by the current PR.
 
 ## Optional LLM Claim Candidates
 
@@ -180,7 +210,7 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 
 - [Methodology](docs/methodology.md): the PR-centered evidence model and rule-design principles.
 - [Evaluation Design](docs/evaluation-design.md): how rules are validated without turning the project into a benchmark effort.
-- [Real PR Input](docs/real-pr-input.md): the normalized PR input shape and the path toward CLI/CI integration.
+- [Real PR Input](docs/real-pr-input.md): direct repository input, Action usage, optional coverage, and deep-probe boundaries.
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
@@ -188,19 +218,25 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 
 ## Current Scope
 
-Version `0.1.0` contains the renamed CLI surface, executable Python/pytest regression fixtures, deterministic rule/evidence artifacts, and normalized real-PR input validation.
+Version `0.1.0` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+
+- production-code changes with no test-file change;
+- uncovered changed Python lines when a coverage XML report is supplied;
+- obvious weak assertions added in changed tests;
+- suspicious test deletion, skip/xfail, or assertion removal;
+- structural mock targets that overlap changed Python symbols;
+- optional bounded targeted probes that survive an explicit test command.
 
 It still does **not** include:
 
-- a direct arbitrary-repository `pr-test-guard check` command;
-- a reusable GitHub Action for external repositories;
-- GitHub API ingestion or PR annotations;
-- configurable advisory/error severity policy;
+- configurable merge-blocking enforcement;
 - per-test coverage mapping;
 - broad semantic assertion or mock classification;
-- safe general-purpose execution of untrusted external repositories.
+- automatic discovery of every repository's test command;
+- safe privileged execution of untrusted PR code;
+- GitHub API ingestion or a hosted service.
 
-The next product milestone is to turn the existing rule logic into a lightweight PR-facing CLI, then expose the same core through GitHub Actions. Advisory output should remain the default; repositories can choose later which high-confidence rules deserve enforcement.
+The next milestone is real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures before expanding the rule set.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,92 @@
+name: PR Test Guard
+description: Lightweight advisory test-quality checks for pull requests.
+author: Tigerless Labs
+
+inputs:
+  base:
+    description: Base ref to compare against. Defaults to origin/$GITHUB_BASE_REF.
+    required: false
+    default: ""
+  coverage:
+    description: Optional path to a coverage.py XML report.
+    required: false
+    default: ""
+  deep:
+    description: Enable bounded targeted probes. Requires test-command.
+    required: false
+    default: "false"
+  test-command:
+    description: Test command used by deep targeted probes, for example pytest -q.
+    required: false
+    default: ""
+  max-probes:
+    description: Maximum number of targeted probes in deep mode.
+    required: false
+    default: "3"
+  python-version:
+    description: Python version used to run PR Test Guard.
+    required: false
+    default: "3.11"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install PR Test Guard
+      shell: bash
+      run: python -m pip install "${{ github.action_path }}"
+
+    - name: Resolve base ref
+      id: base
+      shell: bash
+      env:
+        INPUT_BASE: ${{ inputs.base }}
+      run: |
+        set -euo pipefail
+        base="$INPUT_BASE"
+        if [[ -z "$base" ]]; then
+          if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
+            echo "Unable to infer PR base. Pass 'base' explicitly." >&2
+            exit 2
+          fi
+          base="origin/${GITHUB_BASE_REF}"
+        fi
+
+        if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+          if [[ "$base" == origin/* ]]; then
+            branch="${base#origin/}"
+            git fetch origin "${branch}:refs/remotes/origin/${branch}" --no-tags
+          fi
+        fi
+
+        echo "base=$base" >> "$GITHUB_OUTPUT"
+
+    - name: Run PR Test Guard
+      shell: bash
+      env:
+        INPUT_COVERAGE: ${{ inputs.coverage }}
+        INPUT_DEEP: ${{ inputs.deep }}
+        INPUT_TEST_COMMAND: ${{ inputs.test-command }}
+        INPUT_MAX_PROBES: ${{ inputs.max-probes }}
+        RESOLVED_BASE: ${{ steps.base.outputs.base }}
+      run: |
+        set -euo pipefail
+        args=(check --base "$RESOLVED_BASE" --format github)
+
+        if [[ -n "$INPUT_COVERAGE" ]]; then
+          args+=(--coverage "$INPUT_COVERAGE")
+        fi
+
+        if [[ "$INPUT_DEEP" == "true" ]]; then
+          if [[ -z "$INPUT_TEST_COMMAND" ]]; then
+            echo "deep=true requires test-command." >&2
+            exit 2
+          fi
+          args+=(--deep --test-command "$INPUT_TEST_COMMAND" --max-probes "$INPUT_MAX_PROBES")
+        fi
+
+        pr-test-guard "${args[@]}"

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -61,25 +61,22 @@ A mock candidate should tell a reviewer where to look; it should not automatical
 
 ### Counterfactual evidence
 
-The existing prototype can execute a small set of deterministic behavior weakenings and rerun pytest. Surviving probes can strengthen a test-quality warning.
+The direct checker can execute a small set of deterministic behavior weakenings against changed Python lines. This path is opt-in through `--deep`, requires an explicit test command, and runs in an isolated Git worktree. Surviving probes can strengthen a test-quality warning.
 
-This mechanism is retained as an advanced signal, not as a requirement for the lightweight product direction.
+This is a bounded PR-scoped signal, not a full mutation-testing campaign or repository-wide mutation score.
 
 ## Finding Model
 
-The current prototype retains these finding families:
+The direct checker uses six stable rule ids for the current Python/pytest scope:
 
-- `Missing Test Evidence`
-- `Uncovered Changed Lines`
-- `Weak Assertion`
-- `Issue-Test Mismatch`
-- `Suspicious Fix Without Test`
-- `Mocked Core Path`
-- `CI Scope Weakening`
-- `Counterfactual Survivor`
-- `Evidence Complete`
+- `PTG001` — production code changed with no test-file change;
+- `PTG002` — changed Python line uncovered in a supplied coverage XML;
+- `PTG003` — possible weak assertion added in a changed test;
+- `PTG004` — suspicious test deletion, skip/xfail, or assertion removal;
+- `PTG005` — structural mock target overlaps a changed Python symbol;
+- `PTG006` — bounded targeted probe survives the configured tests.
 
-The public interpretation should be conservative. A finding is a **review signal**. `Evidence Complete` only means that the current fixture did not trigger the targeted evidence-gap rules; it is not a correctness certificate.
+Each result includes a rule id, advisory severity, file/line where available, a short message, and evidence text. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.
 
 ## CLI and CI Boundary
 
@@ -97,6 +94,6 @@ CI integration should be advisory by default. Repositories may later opt into st
 
 ## Current Limits
 
-Version `0.1.0` still uses controlled Python/pytest fixtures to exercise the rule logic. It does not yet provide a general `check` command for arbitrary repositories or a reusable GitHub Action.
+Version `0.1.0` now provides a repository-native `check` command and a reusable GitHub Action for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
 
-The immediate engineering goal is therefore not to add more research machinery. It is to extract the useful rule logic into a direct PR-facing workflow while keeping the current fixtures as regression tests.
+The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -1,86 +1,91 @@
 # Real PR Input
 
-This document defines the current bridge from controlled fixtures to real pull requests.
+PR Test Guard now supports repository-native pull-request analysis. The normal user path is the current Git checkout plus a base ref; the older normalized bundle remains only as a development/compatibility prototype.
 
-PR Test Guard should keep its core analysis independent from one coding agent or one hosting provider. The long-term product shape is a CLI that can analyze local PR context, with GitHub Actions as the first automated integration.
+## Direct Repository Input
 
-## Why Normalize PR Artifacts
+Run inside the PR branch:
 
-A pull request may expose useful context through different places:
+```bash
+pr-test-guard check --base origin/main
+```
 
-- PR title and body;
-- linked issue or task;
-- git diff;
-- test diff;
-- CI summary or logs;
-- coverage reports;
-- optional change-intent text.
+The checker derives the diff from Git and analyzes the current `HEAD` against the merge-base with the supplied base ref.
 
-The checker should use what is available and record what is missing instead of inventing evidence.
+Optional inputs add more signals:
 
-## Current Bundle Shape
+```bash
+pr-test-guard check --base origin/main --coverage coverage.xml
+```
 
-The prototype bundle under `examples/real-pr-bundles/` can include:
+```bash
+pr-test-guard check \
+  --base origin/main \
+  --deep \
+  --test-command "pytest -q" \
+  --max-probes 3
+```
 
-- `bundle.json`
-- `pr.json`
-- `pr.diff`
-- `ci-summary.md`
-- `claim_candidates.json`
-- `missing_artifacts.json`
-- optional issue/task text
-- optional coverage or test results
+The default path does not require a PR body, issue text, LLM output, or a custom JSON bundle.
 
-The current `claim_candidates.json` is a prototype context artifact, not a requirement for every future rule. Straightforward diff- and coverage-based checks should not need an LLM-generated claim layer.
+## What the Direct Checker Reads
 
-## Validation
+The current Python/pytest path uses:
 
-Validate the example bundle with:
+- `git diff <base>...HEAD`;
+- changed production and test files;
+- changed Python lines;
+- changed test assertions and skip/xfail markers;
+- tracked Python tests for structural mock-boundary candidates;
+- optional `coverage.py` XML;
+- optional explicit test command for bounded targeted probes.
+
+Missing optional artifacts are reported as skipped checks, not silently converted into negative evidence.
+
+## GitHub Action
+
+The root `action.yml` wraps the same CLI/core. A consumer repository checks out the PR with enough history to resolve the base and then invokes PR Test Guard:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+- uses: tigerless-labs/pr-test-guard@v0.1.0
+  with:
+    base: origin/${{ github.base_ref }}
+```
+
+The Action emits GitHub warning annotations and appends a job summary. Findings are advisory by default and do not make the Action fail.
+
+## Deep Probe Boundary
+
+`--deep` is opt-in because it executes the repository's configured test command. PR Test Guard first creates an isolated Git worktree at `HEAD`, verifies that the unmodified test command passes, and only then applies a bounded number of supported probes.
+
+This is intentionally different from a full mutation-testing campaign: the probe set is small, scoped to changed Python lines, and used as reviewer evidence rather than as a repository-wide mutation score.
+
+## Normalized Bundle Compatibility
+
+The prototype bundle under `examples/real-pr-bundles/` can still include:
+
+- `bundle.json`;
+- `pr.json`;
+- `pr.diff`;
+- CI/test artifacts;
+- coverage;
+- optional change-intent context;
+- explicit missing-artifact records.
+
+Validate it with:
 
 ```bash
 python3 -m pr_test_guard validate-real-pr-bundles
 ```
 
-The validator checks structure and cross-file consistency. It does not claim that the example represents a real repository or a scored dataset.
-
-## CLI Direction
-
-The target CLI should eventually accept repository-native context directly, for example:
-
-```text
-pr-test-guard check --base <base-ref>
-```
-
-A direct check command should derive the PR diff from git, discover relevant test changes, optionally consume an existing coverage artifact, and emit normalized findings.
-
-That command does not exist in `0.1.0`; the current bundle is preparation for that transition.
-
-## GitHub Actions Direction
-
-GitHub Actions should wrap the same CLI/core rather than becoming a separate analysis engine.
-
-The intended flow is:
-
-```text
-pull_request event
-  -> checkout
-  -> existing project test/coverage job
-  -> PR Test Guard CLI
-  -> annotations / job summary
-```
-
-The default integration should be advisory. A warning such as a possible weak assertion should not automatically block a merge. Repositories may later configure selected high-confidence rules or thresholds as enforcement policy.
-
-## Missing Evidence
-
-Missing evidence is itself useful context, but it must be reported precisely.
-
-For example, if no coverage artifact is available, the tool may say that changed-line coverage was not evaluated. It should not infer that changed code is uncovered.
-
-This distinction is important for a lightweight tool that must work across repositories with different CI setups.
+This bundle is no longer required for normal real-PR use.
 
 ## Security Boundary
 
-A GitHub Action should request the minimum permissions needed for analysis. The checker should not need write access or repository secrets for its default rule path.
+The static/default checker only reads repository content and Git history. Coverage is consumed only when explicitly supplied.
 
-If a future mode executes untrusted PR code, that execution must follow the repository's existing CI trust model rather than silently escalating privileges.
+Deep probes execute a test command chosen by the repository/user. In GitHub Actions, that execution therefore follows the trust boundary of the workflow that opted into it. PR Test Guard does not request repository write permission or secrets for its default advisory path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,23 +1,21 @@
 # Roadmap
 
-PR Test Guard is moving from an evidence-research prototype into a lightweight PR test-quality tool.
+PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-The product direction is intentionally narrow:
-
-> run fast, explain what triggered, surface review signals, and fit naturally into local CLI and CI workflows.
-
-Version `0.1.0` remains pre-release while the public naming and product boundary are stabilized.
+Version `0.1.0` is the first public-ready shape: direct real-PR checking, advisory GitHub Actions integration, static mock-boundary analysis, and optional bounded targeted probes.
 
 ## What Exists in 0.1.0
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
+- `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
+- optional `coverage.py` XML input for changed-line coverage signals;
+- obvious weak-assertion and test-weakening checks;
+- explicit Python mock-boundary candidates on changed symbols;
+- opt-in bounded targeted probes in an isolated Git worktree;
+- text, JSON, and GitHub Actions output;
+- reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
-- changed-line coverage evidence;
-- test-diff and assertion summaries;
-- explicit Python mock-boundary candidates;
-- limited deterministic counterfactual probes;
-- normalized real-PR input bundle validation;
-- JSON and Markdown artifacts for debugging rule behavior.
+- normalized real-PR bundle compatibility for development artifacts.
 
 The fixture runner is development infrastructure for the tool. It is not the product's public benchmark identity.
 
@@ -25,112 +23,69 @@ The fixture runner is development infrastructure for the tool. It is not the pro
 
 ### Lightweight first
 
-Prefer deterministic checks that can run locally or in CI without a hosted service, API key, or large setup burden.
+Prefer deterministic PR-scoped checks that can run locally or in CI without a hosted service or API key.
 
 ### PR first
 
-The primary user context is a pull request: what code changed, what tests changed, what ran, and what obvious test-quality risks deserve review.
+The primary user context is a pull request: what code changed, what tests changed, what ran, and what test-quality risks deserve review.
+
+### Beyond coverage
+
+Patch coverage remains useful, but PR Test Guard should also surface signals that coverage alone cannot answer: obviously weak assertions, mocks that overlap changed paths, and bounded probes that survive the configured tests.
 
 ### Advisory by default
 
-Heuristic signals such as weak assertions or suspicious mocks should default to warnings. Repositories can choose later which high-confidence policies deserve to block merges.
+Heuristic signals default to warnings. Repositories can choose later which high-confidence policies deserve to block merges.
 
 ### CLI core, integrations on top
 
-The analysis logic should live behind a reusable CLI/core. GitHub Actions should wrap that core rather than creating a separate implementation.
+The analysis logic lives behind the reusable CLI/core. GitHub Actions wraps that core rather than creating a separate implementation.
 
-## Stage 1: Rename and Reposition
+## Next: Real-PR Dogfooding
 
-- rename the public project to PR Test Guard;
-- rename package and CLI surfaces;
-- remove benchmark/harness language from the main product story;
-- retain useful existing rule logic and regression fixtures;
-- make README and docs describe the same lightweight PR-checking direction.
-
-## Stage 2: Direct PR Check Command
-
-Add a first repository-native command, for example:
+Run the public rule set on varied real PRs across multiple Python/pytest repositories and record simple reviewer feedback:
 
 ```text
-pr-test-guard check --base <base-ref>
+useful
+false positive
+unclear
+needs more context
 ```
 
-It should initially focus on low-cost inputs:
+Use recurring false-positive patterns to add regression fixtures and tighten rules before expanding the rule family.
 
-- git diff;
-- production/test file changes;
-- assertion/test changes;
-- optional existing coverage report.
+Priority cases:
 
-Avoid requiring a normalized bundle for normal local use.
+- pure refactors with no test changes;
+- existing tests that already cover changed code;
+- legitimate mocks around changed paths;
+- strong assertions that look syntactically simple;
+- test deletion/skip changes with explicit intent;
+- changed code with good coverage but a surviving targeted probe.
 
-## Stage 3: Small Rule Set
+## Next: Output and Policy Controls
 
-Turn the most useful existing logic into explicit, individually configurable rules.
+After dogfooding stabilizes the signals, consider:
 
-Initial candidates:
+- configurable rule enable/disable settings;
+- optional fail-on selected rules or severity;
+- richer GitHub annotations;
+- JSON artifact upload examples;
+- repository path/test mapping configuration.
 
-1. changed production code with no obvious test change;
-2. uncovered changed executable lines when coverage exists;
-3. obvious weak assertion patterns;
-4. suspicious test deletion, skip, xfail, or assertion weakening;
-5. explicit mock candidates on changed behavior paths as warning-only evidence.
+Keep policy separate from detection: the checker identifies signals; the repository decides what blocks a merge.
 
-Each rule should emit:
-
-```text
-rule id
-severity
-file / line when available
-short message
-evidence reference
-```
-
-## Stage 4: GitHub Action
-
-Publish a reusable GitHub Action that invokes the same core CLI on `pull_request` workflows.
-
-First output targets:
-
-- normal workflow logs;
-- GitHub job summary;
-- file/line warnings where supported.
-
-Do not require a backend service.
-
-## Stage 5: Advisory and Enforcement Policy
-
-Add a small configuration surface such as:
-
-```text
-advisory by default
-optional fail-on selected rules or severity
-```
-
-Keep policy separate from detection. The checker identifies signals; the repository decides what blocks a merge.
-
-## Stage 6: False-Positive Reduction
-
-Expand regression fixtures with negative controls and dogfood the rules on real PRs.
-
-Prioritize noisy areas:
-
-- weak assertions;
-- mock boundaries;
-- existing-test coverage when no test file changed;
-- refactors and non-behavioral changes;
-- test deletion/skip intent.
-
-## Stage 7: Broader CI and Language Support
+## Later: Broader Coverage and Language Support
 
 After the GitHub/Python path is stable, consider:
 
-- GitLab or other CI wrappers;
+- per-test coverage mapping;
 - JavaScript/TypeScript test patterns;
-- other coverage formats;
-- repository configuration for path/test mapping.
+- additional coverage formats;
+- GitLab or other CI wrappers;
+- broader but still conservative mock/assertion analysis.
 
-## Stage 8: Optional Semantic Assistance
+## Optional Semantic Assistance
 
 Only after deterministic rules are useful on their own, consider optional semantic assistance for ambiguous mappings.
 
@@ -148,4 +103,5 @@ It should remain:
 - proving overall PR correctness;
 - replacing existing test runners or coverage tools;
 - becoming a general-purpose AI code-review agent;
-- running a hosted service when a local/CI workflow is sufficient.
+- running a hosted service when a local/CI workflow is sufficient;
+- running an unbounded mutation-testing campaign on every PR.

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -1,0 +1,716 @@
+"""Repository-native pull-request analysis for PR Test Guard."""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .finding import Finding
+
+
+PROBE_REPLACEMENTS: tuple[tuple[str, str, str], ...] = (
+    ("return 400", "return 200", "weaken HTTP 400 return to success"),
+    ("return 401", "return 200", "weaken HTTP 401 return to success"),
+    ("return 403", "return 200", "weaken HTTP 403 return to success"),
+    ("return 404", "return 200", "weaken HTTP 404 return to success"),
+    ("return 409", "return 200", "weaken HTTP 409 return to success"),
+    ("return 422", "return 200", "weaken HTTP 422 return to success"),
+    ("return 500", "return 200", "weaken HTTP 500 return to success"),
+    ("return False", "return True", "flip false return"),
+    ("return True", "return False", "flip true return"),
+    (" <= ", " < ", "weaken inclusive upper-bound comparison"),
+    (" >= ", " > ", "weaken inclusive lower-bound comparison"),
+    (" == ", " != ", "flip equality comparison"),
+)
+
+
+class CheckError(RuntimeError):
+    """Raised when a repository cannot be analyzed safely or consistently."""
+
+
+@dataclass(slots=True)
+class FileDiff:
+    path: str
+    status: str = "M"
+    added: list[tuple[int, str]] | None = None
+    removed: list[tuple[int, str]] | None = None
+
+    def __post_init__(self) -> None:
+        if self.added is None:
+            self.added = []
+        if self.removed is None:
+            self.removed = []
+
+
+@dataclass(slots=True)
+class AnalysisResult:
+    repo_root: Path
+    base: str
+    head: str
+    files: list[FileDiff]
+    findings: list[Finding]
+    notes: list[str]
+    probe_summary: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "base": self.base,
+            "head": self.head,
+            "summary": {
+                "changed_files": len(self.files),
+                "production_files": sum(1 for item in self.files if is_python_path(item.path) and not is_test_path(item.path)),
+                "test_files": sum(1 for item in self.files if is_test_path(item.path)),
+                "findings": len(self.findings),
+                "notes": len(self.notes),
+            },
+            "findings": [item.to_dict() for item in self.findings],
+            "notes": self.notes,
+            "probes": self.probe_summary,
+        }
+
+
+def run_command(
+    command: list[str],
+    cwd: Path,
+    *,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        rendered = " ".join(shlex.quote(part) for part in command)
+        detail = (result.stderr or result.stdout).strip()
+        raise CheckError(f"command failed ({rendered}): {detail}")
+    return result
+
+
+def repository_root(cwd: Path) -> Path:
+    result = run_command(["git", "rev-parse", "--show-toplevel"], cwd)
+    if result.returncode != 0:
+        raise CheckError("current directory is not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def resolve_commit(repo_root: Path, ref: str) -> str:
+    result = run_command(["git", "rev-parse", "--verify", f"{ref}^{{commit}}"], repo_root)
+    if result.returncode != 0:
+        raise CheckError(f"base ref does not resolve to a commit: {ref}")
+    return result.stdout.strip()
+
+
+def is_test_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    parts = normalized.split("/")
+    filename = parts[-1]
+    return (
+        "tests" in parts
+        or "test" in parts[:-1]
+        or filename.startswith("test_")
+        or filename.endswith("_test.py")
+    )
+
+
+def is_python_path(path: str) -> bool:
+    return path.endswith(".py")
+
+
+def parse_name_status(repo_root: Path, base: str) -> dict[str, str]:
+    result = run_command(
+        ["git", "diff", "--name-status", "-M", f"{base}...HEAD", "--"],
+        repo_root,
+        check=True,
+    )
+    statuses: dict[str, str] = {}
+    for raw_line in result.stdout.splitlines():
+        if not raw_line.strip():
+            continue
+        parts = raw_line.split("\t")
+        code = parts[0]
+        if code.startswith("R") and len(parts) >= 3:
+            statuses[parts[2]] = code
+        elif len(parts) >= 2:
+            statuses[parts[1]] = code
+    return statuses
+
+
+def parse_diff(repo_root: Path, base: str) -> list[FileDiff]:
+    result = run_command(
+        ["git", "diff", "--unified=0", "--no-ext-diff", "--find-renames", f"{base}...HEAD", "--"],
+        repo_root,
+        check=True,
+    )
+    statuses = parse_name_status(repo_root, base)
+    files: dict[str, FileDiff] = {}
+    current: FileDiff | None = None
+    old_line: int | None = None
+    new_line: int | None = None
+
+    for raw_line in result.stdout.splitlines():
+        match = re.match(r"^diff --git a/(.*?) b/(.*?)$", raw_line)
+        if match:
+            path = match.group(2)
+            current = files.setdefault(path, FileDiff(path=path, status=statuses.get(path, "M")))
+            old_line = None
+            new_line = None
+            continue
+
+        hunk = re.match(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@", raw_line)
+        if hunk:
+            old_line = int(hunk.group(1))
+            new_line = int(hunk.group(2))
+            continue
+
+        if current is None or old_line is None or new_line is None:
+            continue
+
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            current.added.append((new_line, raw_line[1:]))
+            new_line += 1
+        elif raw_line.startswith("-") and not raw_line.startswith("---"):
+            current.removed.append((old_line, raw_line[1:]))
+            old_line += 1
+        else:
+            old_line += 1
+            new_line += 1
+
+    for path, status in statuses.items():
+        files.setdefault(path, FileDiff(path=path, status=status))
+
+    return sorted(files.values(), key=lambda item: item.path)
+
+
+def changed_code_lines(files: list[FileDiff]) -> dict[str, list[dict[str, Any]]]:
+    changed: dict[str, list[dict[str, Any]]] = {}
+    for item in files:
+        if is_test_path(item.path) or not is_python_path(item.path):
+            continue
+        lines = []
+        for line, content in item.added:
+            stripped = content.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            lines.append({"line": line, "content": content})
+        if lines:
+            changed[item.path] = lines
+    return changed
+
+
+def source_for_node(source: str, node: ast.AST) -> str:
+    return (ast.get_source_segment(source, node) or "").strip()
+
+
+def classify_assertion(node: ast.Assert) -> str:
+    test = node.test
+    if isinstance(test, ast.Compare):
+        ops = [type(op).__name__ for op in test.ops]
+        if any(op in {"IsNot", "Is"} for op in ops) and any(
+            isinstance(comp, ast.Constant) and comp.value is None for comp in test.comparators
+        ):
+            return "existence_or_none_check"
+        return "comparison"
+    if isinstance(test, ast.Name):
+        return "truthiness_check"
+    if isinstance(test, ast.Call):
+        return "call_truthiness_check"
+    if isinstance(test, ast.Attribute):
+        return "truthiness_check"
+    return type(test).__name__
+
+
+def weak_assertion_findings(repo_root: Path, files: list[FileDiff]) -> list[Finding]:
+    findings: list[Finding] = []
+    for diff in files:
+        if not is_test_path(diff.path) or not diff.path.endswith(".py"):
+            continue
+        path = repo_root / diff.path
+        if not path.is_file():
+            continue
+        added_lines = {line for line, _ in diff.added}
+        if not added_lines:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assert) or node.lineno not in added_lines:
+                continue
+            shape = classify_assertion(node)
+            if shape not in {"existence_or_none_check", "truthiness_check", "call_truthiness_check"}:
+                continue
+            evidence = source_for_node(source, node)
+            findings.append(
+                Finding(
+                    rule_id="PTG003",
+                    severity="warning",
+                    file=diff.path,
+                    line=node.lineno,
+                    message="Possible weak assertion; review whether it constrains the behavior changed by this PR.",
+                    evidence=evidence,
+                )
+            )
+    return findings
+
+
+def missing_test_change_findings(files: list[FileDiff]) -> list[Finding]:
+    production = [item for item in files if not is_test_path(item.path) and is_python_path(item.path)]
+    test_changes = [item for item in files if is_test_path(item.path)]
+    if not production or test_changes:
+        return []
+    first = production[0]
+    return [
+        Finding(
+            rule_id="PTG001",
+            severity="warning",
+            file=first.path,
+            line=first.added[0][0] if first.added else None,
+            message="Production code changed, but this PR contains no test-file change. Existing tests may still cover it; review whether extra test evidence is needed.",
+            evidence=f"{len(production)} production file(s) changed; 0 test files changed",
+        )
+    ]
+
+
+def test_weakening_findings(repo_root: Path, files: list[FileDiff]) -> list[Finding]:
+    findings: list[Finding] = []
+    skip_names = {
+        "pytest.mark.skip",
+        "pytest.mark.skipif",
+        "pytest.mark.xfail",
+        "pytest.skip",
+        "unittest.skip",
+        "unittest.expectedFailure",
+    }
+    for diff in files:
+        if not is_test_path(diff.path):
+            continue
+        if diff.status.startswith("D"):
+            findings.append(
+                Finding(
+                    rule_id="PTG004",
+                    severity="warning",
+                    file=diff.path,
+                    line=None,
+                    message="A test file was deleted in this PR; review whether validation scope was intentionally reduced.",
+                    evidence="deleted test file",
+                )
+            )
+            continue
+
+        path = repo_root / diff.path
+        added_lines = {line for line, _ in diff.added}
+        if path.is_file() and path.suffix == ".py" and added_lines:
+            try:
+                source = path.read_text(encoding="utf-8")
+                tree = ast.parse(source)
+            except (OSError, SyntaxError, UnicodeDecodeError):
+                tree = None
+            if tree is not None:
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Call) and node.lineno in added_lines:
+                        name = call_name(node)
+                        if name in skip_names:
+                            findings.append(
+                                Finding(
+                                    rule_id="PTG004",
+                                    severity="warning",
+                                    file=diff.path,
+                                    line=node.lineno,
+                                    message="Test skip/xfail behavior was added; review whether the PR weakens validation scope.",
+                                    evidence=source_for_node(source, node),
+                                )
+                            )
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        for decorator in node.decorator_list:
+                            name = call_name(decorator) if isinstance(decorator, ast.Call) else dotted_name(decorator)
+                            line = getattr(decorator, "lineno", None)
+                            if line in added_lines and name in skip_names:
+                                findings.append(
+                                    Finding(
+                                        rule_id="PTG004",
+                                        severity="warning",
+                                        file=diff.path,
+                                        line=line,
+                                        message="Test skip/xfail behavior was added; review whether the PR weakens validation scope.",
+                                        evidence=source_for_node(source, decorator),
+                                    )
+                                )
+
+        removed_asserts = [content.strip() for _, content in diff.removed if content.strip().startswith("assert ")]
+        added_asserts = [content.strip() for _, content in diff.added if content.strip().startswith("assert ")]
+        if len(removed_asserts) > len(added_asserts):
+            findings.append(
+                Finding(
+                    rule_id="PTG004",
+                    severity="warning",
+                    file=diff.path,
+                    line=diff.added[0][0] if diff.added else None,
+                    message="Assertions were removed without an equal number of replacement assertions; review whether the test became weaker.",
+                    evidence=f"removed assertions={len(removed_asserts)}, added assertions={len(added_asserts)}",
+                )
+            )
+    return findings
+
+
+def parse_coverage_xml(path: Path) -> dict[str, dict[int, int]]:
+    if not path.is_file():
+        raise CheckError(f"coverage file not found: {path}")
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        raise CheckError(f"coverage XML is malformed: {path}: {exc}") from exc
+    covered: dict[str, dict[int, int]] = {}
+    for class_node in root.findall(".//class"):
+        filename = class_node.attrib.get("filename")
+        if not filename:
+            continue
+        lines: dict[int, int] = {}
+        for line_node in class_node.findall("./lines/line"):
+            number = line_node.attrib.get("number")
+            hits = line_node.attrib.get("hits", "0")
+            if number:
+                lines[int(number)] = int(hits)
+        covered[filename] = lines
+    return covered
+
+
+def coverage_hits(coverage: dict[str, dict[int, int]], file_path: str, line: int) -> int | None:
+    for candidate in (file_path, f"./{file_path}"):
+        if candidate in coverage:
+            return coverage[candidate].get(line)
+    for filename, lines in coverage.items():
+        if filename.endswith(file_path):
+            return lines.get(line)
+    return None
+
+
+def uncovered_line_findings(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+    coverage_path: str | None,
+    notes: list[str],
+) -> list[Finding]:
+    if not coverage_path:
+        notes.append("PTG002 skipped: no coverage XML was provided.")
+        return []
+    path = Path(coverage_path)
+    if not path.is_absolute():
+        path = repo_root / path
+    coverage = parse_coverage_xml(path)
+    findings: list[Finding] = []
+    for file_path, lines in changed.items():
+        for item in lines:
+            hits = coverage_hits(coverage, file_path, item["line"])
+            if hits is None:
+                continue
+            if hits == 0:
+                findings.append(
+                    Finding(
+                        rule_id="PTG002",
+                        severity="warning",
+                        file=file_path,
+                        line=item["line"],
+                        message="Changed executable line is not covered by the supplied coverage report.",
+                        evidence=item["content"].strip(),
+                    )
+                )
+    return findings
+
+
+def dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def call_name(node: ast.AST) -> str | None:
+    return dotted_name(node.func) if isinstance(node, ast.Call) else None
+
+
+def collect_changed_symbols(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    for rel_path, line_items in changed.items():
+        path = repo_root / rel_path
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        changed_lines = {item["line"] for item in line_items}
+        module_name = rel_path.removesuffix(".py").replace("/", ".")
+        short_module = Path(rel_path).stem
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            start = getattr(node, "lineno", None)
+            end = getattr(node, "end_lineno", start)
+            if start is None or end is None or not any(start <= line <= end for line in changed_lines):
+                continue
+            symbols.append(
+                {
+                    "file": rel_path,
+                    "name": node.name,
+                    "line": start,
+                    "candidate_targets": sorted({node.name, f"{short_module}.{node.name}", f"{module_name}.{node.name}"}),
+                }
+            )
+    return symbols
+
+
+def extract_mock_target(source: str, node: ast.Call) -> tuple[str | None, str | None]:
+    name = call_name(node)
+    if not name:
+        return None, None
+    if name.endswith("patch.object") and len(node.args) >= 2:
+        attr = node.args[1]
+        if isinstance(attr, ast.Constant) and isinstance(attr.value, str):
+            return f"{source_for_node(source, node.args[0])}.{attr.value}", "patch.object"
+    if name == "patch" or name.endswith(".patch"):
+        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            return node.args[0].value, "patch"
+    if name.endswith(".setattr") and len(node.args) >= 2:
+        if isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            return node.args[0].value, "setattr"
+        if isinstance(node.args[1], ast.Constant) and isinstance(node.args[1].value, str):
+            return f"{source_for_node(source, node.args[0])}.{node.args[1].value}", "setattr"
+    return None, None
+
+
+def mock_matches(target: str, candidates: list[str]) -> bool:
+    normalized = target.strip("'\"")
+    return any(
+        normalized == candidate
+        or normalized.endswith(f".{candidate}")
+        or candidate.endswith(f".{normalized}")
+        for candidate in candidates
+    )
+
+
+def tracked_test_files(repo_root: Path) -> list[str]:
+    result = run_command(["git", "ls-files", "*.py"], repo_root, check=True)
+    return [line for line in result.stdout.splitlines() if line and is_test_path(line)]
+
+
+def mock_boundary_findings(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+) -> list[Finding]:
+    symbols = collect_changed_symbols(repo_root, changed)
+    if not symbols:
+        return []
+    findings: list[Finding] = []
+    seen: set[tuple[str, int, str]] = set()
+    for rel_path in tracked_test_files(repo_root):
+        path = repo_root / rel_path
+        if not path.is_file():
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            target, style = extract_mock_target(source, call)
+            if not target or not style:
+                continue
+            matched = [symbol for symbol in symbols if mock_matches(target, symbol["candidate_targets"])]
+            if not matched:
+                continue
+            key = (rel_path, call.lineno, target)
+            if key in seen:
+                continue
+            seen.add(key)
+            changed_names = ", ".join(sorted({item["name"] for item in matched}))
+            findings.append(
+                Finding(
+                    rule_id="PTG005",
+                    severity="warning",
+                    file=rel_path,
+                    line=call.lineno,
+                    message="A test mocks a path that overlaps code changed by this PR; review whether the real changed behavior is still exercised.",
+                    evidence=f"{style} target={target}; changed symbol(s)={changed_names}",
+                )
+            )
+    return findings
+
+
+def generate_probes(
+    changed: dict[str, list[dict[str, Any]]],
+    max_probes: int,
+) -> list[dict[str, Any]]:
+    probes: list[dict[str, Any]] = []
+    for rel_path, lines in changed.items():
+        for item in lines:
+            content = item["content"]
+            for original, replacement, rationale in PROBE_REPLACEMENTS:
+                if original not in content:
+                    continue
+                probes.append(
+                    {
+                        "id": f"P{len(probes) + 1}",
+                        "file": rel_path,
+                        "line": item["line"],
+                        "original": original,
+                        "replacement": replacement,
+                        "rationale": rationale,
+                    }
+                )
+                break
+            if len(probes) >= max_probes:
+                return probes
+    return probes
+
+
+def run_shell(command: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, shell=True, capture_output=True, text=True)
+
+
+def targeted_probe_findings(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+    *,
+    deep: bool,
+    test_command: str | None,
+    max_probes: int,
+    notes: list[str],
+) -> tuple[list[Finding], dict[str, Any]]:
+    empty_summary = {"enabled": deep, "generated": 0, "applied": 0, "survived": 0, "baseline_passed": None}
+    if not deep:
+        notes.append("PTG006 skipped: deep targeted probes are opt-in (--deep).")
+        return [], empty_summary
+    if not test_command:
+        raise CheckError("--deep requires --test-command so PR Test Guard knows how to rerun the repository tests")
+
+    probes = generate_probes(changed, max_probes=max(1, max_probes))
+    summary = {**empty_summary, "generated": len(probes)}
+    if not probes:
+        notes.append("PTG006: no supported targeted probe candidate was found in the changed Python lines.")
+        return [], summary
+
+    findings: list[Finding] = []
+    with tempfile.TemporaryDirectory(prefix="pr-test-guard-worktree-") as temp_dir:
+        worktree = Path(temp_dir)
+        add_result = run_command(["git", "worktree", "add", "--detach", str(worktree), "HEAD"], repo_root)
+        if add_result.returncode != 0:
+            detail = (add_result.stderr or add_result.stdout).strip()
+            raise CheckError(f"failed to create isolated probe worktree: {detail}")
+        try:
+            baseline = run_shell(test_command, worktree)
+            summary["baseline_passed"] = baseline.returncode == 0
+            if baseline.returncode != 0:
+                notes.append("PTG006 skipped: the configured test command fails on the unmodified PR checkout.")
+                return [], summary
+
+            for probe in probes:
+                path = worktree / probe["file"]
+                if not path.is_file():
+                    continue
+                original_text = path.read_text(encoding="utf-8")
+                lines = original_text.splitlines(keepends=True)
+                index = probe["line"] - 1
+                if index < 0 or index >= len(lines) or probe["original"] not in lines[index]:
+                    continue
+                lines[index] = lines[index].replace(probe["original"], probe["replacement"], 1)
+                path.write_text("".join(lines), encoding="utf-8")
+                summary["applied"] += 1
+                result = run_shell(test_command, worktree)
+                path.write_text(original_text, encoding="utf-8")
+                if result.returncode == 0:
+                    summary["survived"] += 1
+                    findings.append(
+                        Finding(
+                            rule_id="PTG006",
+                            severity="warning",
+                            file=probe["file"],
+                            line=probe["line"],
+                            message="A bounded targeted probe survived the configured tests; the tests may be insensitive to this changed behavior.",
+                            evidence=f"{probe['original'].strip()} -> {probe['replacement'].strip()} ({probe['rationale']})",
+                        )
+                    )
+        finally:
+            run_command(["git", "worktree", "remove", "--force", str(worktree)], repo_root)
+            run_command(["git", "worktree", "prune"], repo_root)
+
+    return findings, summary
+
+
+def dedupe_findings(findings: list[Finding]) -> list[Finding]:
+    seen: set[tuple[str, str | None, int | None, str]] = set()
+    unique: list[Finding] = []
+    for item in findings:
+        key = (item.rule_id, item.file, item.line, item.message)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return sorted(unique, key=lambda item: (item.rule_id, item.file or "", item.line or 0, item.message))
+
+
+def analyze_repository(
+    cwd: Path,
+    *,
+    base: str,
+    coverage_path: str | None = None,
+    deep: bool = False,
+    test_command: str | None = None,
+    max_probes: int = 3,
+) -> AnalysisResult:
+    repo_root = repository_root(cwd)
+    resolve_commit(repo_root, base)
+    head = resolve_commit(repo_root, "HEAD")
+    files = parse_diff(repo_root, base)
+    changed = changed_code_lines(files)
+    notes: list[str] = []
+
+    findings: list[Finding] = []
+    findings.extend(missing_test_change_findings(files))
+    findings.extend(uncovered_line_findings(repo_root, changed, coverage_path, notes))
+    findings.extend(weak_assertion_findings(repo_root, files))
+    findings.extend(test_weakening_findings(repo_root, files))
+    findings.extend(mock_boundary_findings(repo_root, changed))
+    probe_findings, probe_summary = targeted_probe_findings(
+        repo_root,
+        changed,
+        deep=deep,
+        test_command=test_command,
+        max_probes=max_probes,
+        notes=notes,
+    )
+    findings.extend(probe_findings)
+
+    if not files:
+        notes.append(f"No changes found between {base} and HEAD.")
+    elif not changed:
+        notes.append("No changed Python production lines were found; Python-specific coverage/mock/probe rules may be quiet.")
+
+    return AnalysisResult(
+        repo_root=repo_root,
+        base=base,
+        head=head,
+        files=files,
+        findings=dedupe_findings(findings),
+        notes=notes,
+        probe_summary=probe_summary,
+    )
+
+
+def default_base() -> str:
+    github_base = os.environ.get("GITHUB_BASE_REF", "").strip()
+    if github_base:
+        return f"origin/{github_base}"
+    return "origin/main"

--- a/pr_test_guard/cli.py
+++ b/pr_test_guard/cli.py
@@ -1,4 +1,4 @@
-"""Stable source-tree CLI for PR Test Guard."""
+"""CLI entrypoint for PR Test Guard."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ import importlib
 import sys
 from pathlib import Path
 
+from .check import CheckError, analyze_repository, default_base
+from .reporters import emit_github, render_json, render_text
 from .version import __version__
 
 
@@ -15,7 +17,7 @@ SCRIPTS_DIR = ROOT / "scripts"
 
 
 def invoke_script(module_name: str, args: list[str]) -> int:
-    """Run an existing script module while preserving its command contract."""
+    """Run an existing development script while preserving its command contract."""
     if str(SCRIPTS_DIR) not in sys.path:
         sys.path.insert(0, str(SCRIPTS_DIR))
 
@@ -32,8 +34,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pr-test-guard",
         description=(
-            "Run PR Test Guard regression fixtures and real-PR input checks. "
-            "Findings are review signals, not merge verdicts."
+            "Lightweight PR test-quality checks. Findings are advisory review signals, "
+            "not merge verdicts."
         ),
     )
     parser.add_argument(
@@ -43,6 +45,43 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     subcommands = parser.add_subparsers(dest="command")
+
+    check = subcommands.add_parser(
+        "check",
+        help="analyze the current repository diff against a base ref",
+    )
+    check.add_argument(
+        "--base",
+        default=None,
+        help="base ref for the PR diff (default: origin/$GITHUB_BASE_REF in CI, otherwise origin/main)",
+    )
+    check.add_argument(
+        "--coverage",
+        default=None,
+        help="optional coverage.py XML report used for changed-line coverage checks",
+    )
+    check.add_argument(
+        "--deep",
+        action="store_true",
+        help="enable bounded targeted probes in an isolated git worktree",
+    )
+    check.add_argument(
+        "--test-command",
+        default=None,
+        help="test command used by --deep, for example 'pytest -q'",
+    )
+    check.add_argument(
+        "--max-probes",
+        type=int,
+        default=3,
+        help="maximum targeted probes to run in deep mode (default: 3)",
+    )
+    check.add_argument(
+        "--format",
+        choices=("text", "json", "github"),
+        default="text",
+        help="output format (default: text)",
+    )
 
     validate_cases = subcommands.add_parser(
         "validate-cases",
@@ -94,6 +133,32 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def run_check(parsed: argparse.Namespace) -> int:
+    base = parsed.base or default_base()
+    try:
+        result = analyze_repository(
+            Path.cwd(),
+            base=base,
+            coverage_path=parsed.coverage,
+            deep=parsed.deep,
+            test_command=parsed.test_command,
+            max_probes=parsed.max_probes,
+        )
+    except CheckError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if parsed.format == "json":
+        sys.stdout.write(render_json(result))
+    elif parsed.format == "github":
+        sys.stdout.write(emit_github(result))
+    else:
+        sys.stdout.write(render_text(result))
+
+    # Findings are advisory by default. A successful analysis exits 0 even when warnings exist.
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args_list = list(argv) if argv is not None else sys.argv[1:]
     parser = build_parser()
@@ -102,6 +167,9 @@ def main(argv: list[str] | None = None) -> int:
     if parsed.version or parsed.command == "version":
         print(__version__)
         return 0
+
+    if parsed.command == "check":
+        return run_check(parsed)
 
     if parsed.command == "validate-cases":
         script_args = ["--cases-root", parsed.cases_root]

--- a/pr_test_guard/finding.py
+++ b/pr_test_guard/finding.py
@@ -1,0 +1,20 @@
+"""Finding model shared by CLI and CI reporters."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One advisory PR test-quality signal."""
+
+    rule_id: str
+    severity: str
+    file: str | None
+    line: int | None
+    message: str
+    evidence: str | None = None
+
+    def to_dict(self) -> dict[str, object | None]:
+        return asdict(self)

--- a/pr_test_guard/reporters.py
+++ b/pr_test_guard/reporters.py
@@ -1,0 +1,111 @@
+"""Human, JSON, and GitHub Actions output for PR Test Guard."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from .check import AnalysisResult
+from .finding import Finding
+
+
+def _location(item: Finding) -> str:
+    if item.file and item.line:
+        return f"{item.file}:{item.line}"
+    if item.file:
+        return item.file
+    return "repository"
+
+
+def render_text(result: AnalysisResult) -> str:
+    production = sum(1 for item in result.files if item.path.endswith(".py") and not _is_test_path_for_report(item.path))
+    tests = sum(1 for item in result.files if _is_test_path_for_report(item.path))
+    lines = [
+        "PR Test Guard",
+        "─────────────",
+        f"Base: {result.base}",
+        f"Changed files: {len(result.files)} ({production} Python production, {tests} test)",
+        "",
+    ]
+    if result.findings:
+        lines.append(f"{len(result.findings)} review signal(s)")
+        lines.append("")
+        for item in result.findings:
+            lines.append(f"⚠ {item.rule_id} {_location(item)}")
+            lines.append(f"  {item.message}")
+            if item.evidence:
+                lines.append(f"  Evidence: {item.evidence}")
+            lines.append("")
+    else:
+        lines.extend(["No review signals found by the enabled rules.", ""])
+
+    if result.notes:
+        lines.append("Notes")
+        for note in result.notes:
+            lines.append(f"- {note}")
+        lines.append("")
+
+    lines.append("Result: advisory — findings do not block merge by default.")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_json(result: AnalysisResult) -> str:
+    return json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n"
+
+
+def _escape_workflow_value(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _annotation(item: Finding) -> str:
+    attrs = []
+    if item.file:
+        attrs.append(f"file={_escape_workflow_value(item.file)}")
+    if item.line:
+        attrs.append(f"line={item.line}")
+    metadata = f" {','.join(attrs)}" if attrs else ""
+    message = f"[{item.rule_id}] {item.message}"
+    if item.evidence:
+        message += f" Evidence: {item.evidence}"
+    return f"::warning{metadata}::{_escape_workflow_value(message)}"
+
+
+def github_summary(result: AnalysisResult) -> str:
+    lines = [
+        "## PR Test Guard",
+        "",
+        f"**{len(result.findings)} review signal(s)** found between `{result.base}` and `HEAD`.",
+        "",
+    ]
+    if result.findings:
+        lines.extend(["| Rule | Location | Signal |", "| --- | --- | --- |"])
+        for item in result.findings:
+            lines.append(f"| `{item.rule_id}` | `{_location(item)}` | {item.message} |")
+        lines.append("")
+    else:
+        lines.extend(["No review signals found by the enabled rules.", ""])
+    if result.notes:
+        lines.append("### Notes")
+        lines.append("")
+        for note in result.notes:
+            lines.append(f"- {note}")
+        lines.append("")
+    lines.append("_Advisory by default: findings do not fail the job unless a repository adds its own enforcement policy._")
+    return "\n".join(lines) + "\n"
+
+
+def emit_github(result: AnalysisResult) -> str:
+    output_lines = [_annotation(item) for item in result.findings]
+    output_lines.append(f"PR Test Guard: {len(result.findings)} review signal(s); advisory result.")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        Path(summary_path).open("a", encoding="utf-8").write(github_summary(result))
+    return "\n".join(output_lines) + "\n"
+
+
+def _is_test_path_for_report(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    parts = normalized.split("/")
+    filename = parts[-1]
+    return "tests" in parts or "test" in parts[:-1] or filename.startswith("test_") or filename.endswith("_test.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,13 @@ license = { file = "LICENSE" }
 authors = [
   { name = "Tigerless Labs" }
 ]
-dependencies = [
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
   "coverage",
   "pytest"
 ]
-
-[project.optional-dependencies]
 llm = [
   "openai"
 ]

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pr_test_guard.check import analyze_repository
+
+
+def run(*args: str, cwd: Path) -> None:
+    subprocess.run(list(args), cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run("git", "init", "-b", "main", cwd=repo)
+    run("git", "config", "user.name", "Test User", cwd=repo)
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    return repo
+
+
+def commit_all(repo: Path, message: str) -> None:
+    run("git", "add", "-A", cwd=repo)
+    run("git", "commit", "-m", message, cwd=repo)
+
+
+def rule_ids(result) -> set[str]:
+    return {item.rule_id for item in result.findings}
+
+
+def test_missing_test_change_is_advisory_signal(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    write(repo / "tests/test_app.py", "from app import value\n\ndef test_value():\n    assert value() == 1\n")
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def value():\n    return 2\n")
+    commit_all(repo, "change production only")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    assert "PTG001" in rule_ids(result)
+
+
+def test_weak_assertion_and_mock_boundary_are_detected(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "payment.py", "def charge(amount):\n    return amount > 0\n")
+    write(
+        repo / "tests/test_payment.py",
+        "from payment import charge\n\ndef test_charge():\n    assert charge(1) is True\n",
+    )
+    commit_all(repo, "base")
+
+    write(repo / "payment.py", "def charge(amount):\n    return amount >= 0\n")
+    write(
+        repo / "tests/test_payment.py",
+        "from unittest.mock import patch\nfrom payment import charge\n\n"
+        "@patch('payment.charge')\ndef test_charge(mock_charge):\n    mock_charge.return_value = True\n    result = charge(0)\n    assert result is not None\n",
+    )
+    commit_all(repo, "change behavior and test")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    ids = rule_ids(result)
+    assert "PTG003" in ids
+    assert "PTG005" in ids
+
+
+def test_test_skip_is_detected(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    write(repo / "tests/test_app.py", "from app import value\n\ndef test_value():\n    assert value() == 1\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "tests/test_app.py",
+        "import pytest\nfrom app import value\n\n@pytest.mark.skip(reason='later')\ndef test_value():\n    assert value() == 1\n",
+    )
+    commit_all(repo, "skip test")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    assert "PTG004" in rule_ids(result)
+
+
+def test_uncovered_changed_line_uses_supplied_coverage(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    write(repo / "tests/test_app.py", "from app import value\n\ndef test_value():\n    assert value() == 1\n")
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def value():\n    if True:\n        return 2\n")
+    write(repo / "tests/test_app.py", "from app import value\n\ndef test_value():\n    assert value() == 2\n")
+    commit_all(repo, "change")
+
+    coverage = repo / "coverage.xml"
+    coverage.write_text(
+        "<?xml version='1.0' ?><coverage><packages><package><classes>"
+        "<class filename='app.py'><lines>"
+        "<line number='1' hits='1'/><line number='2' hits='0'/><line number='3' hits='0'/>"
+        "</lines></class></classes></package></packages></coverage>",
+        encoding="utf-8",
+    )
+
+    result = analyze_repository(repo, base="HEAD~1", coverage_path="coverage.xml")
+    assert "PTG002" in rule_ids(result)
+
+
+def test_targeted_probe_survivor_runs_in_isolated_worktree(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def status(ok):\n    return 400\n")
+    write(repo / "tests/test_app.py", "from app import status\n\ndef test_status():\n    assert status(False) is not None\n")
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def status(ok):\n    if not ok:\n        return 400\n    return 200\n")
+    write(repo / "tests/test_app.py", "from app import status\n\ndef test_status():\n    assert status(False) is not None\n")
+    commit_all(repo, "add branch")
+
+    result = analyze_repository(
+        repo,
+        base="HEAD~1",
+        deep=True,
+        test_command="python -m pytest -q",
+        max_probes=1,
+    )
+    assert "PTG006" in rule_ids(result)
+    assert result.probe_summary["baseline_passed"] is True
+    assert result.probe_summary["survived"] == 1
+    assert run_worktree_list(repo) == 1
+
+
+def run_worktree_list(repo: Path) -> int:
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sum(1 for line in result.stdout.splitlines() if line.startswith("worktree "))
+
+
+def test_skip_text_inside_fixture_string_is_not_a_real_skip(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    write(repo / "tests/test_meta.py", "def test_meta():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "tests/test_meta.py",
+        "def test_meta():\n"
+        "    sample = \"@pytest.mark.skip(reason='example only')\"\n"
+        "    assert sample\n",
+    )
+    commit_all(repo, "fixture string")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    assert "PTG004" not in rule_ids(result)


### PR DESCRIPTION
Adds repository-native PR analysis through `pr-test-guard check --base <ref>`, with advisory signals for missing test changes, changed-line coverage gaps, weak assertions, suspicious test weakening, changed-path mock boundaries, and optional bounded targeted probes. The same CLI/core is exposed through a reusable GitHub Action with warning annotations and job summaries. Findings remain advisory by default and version stays at 0.1.0.