### PR TITLE
Improve PTG005 mock-boundary precision with Python symbol resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The project is CLI-first and designed to fit naturally into CI. Its default beha
 
 ## Quick Start
 
-Install from the source tree while `0.1.0` is being prepared for release:
+Install from a source checkout:
 
 ```bash
 python3 -m pip install -e .
@@ -121,7 +121,7 @@ The direct `check` command currently emits six PR-scoped rule families:
 | `PTG002` | A changed Python line is uncovered in the supplied coverage XML. |
 | `PTG003` | A newly added assertion has an obviously weak existence/truthiness shape. |
 | `PTG004` | A test was deleted, skipped/xfail-marked, or lost assertions. |
-| `PTG005` | A structural mock target overlaps a Python symbol changed by the PR. |
+| `PTG005` | A resolved Python mock target overlaps a symbol changed by the PR, with conservative handling of unresolved cases. |
 | `PTG006` | An opt-in bounded targeted probe survives the configured tests. |
 
 These are review-oriented signals. Heuristic findings such as `PTG003` and `PTG005` are advisory by default rather than automatic reasons to block a merge. The older fixture runner retains its research-prototype labels internally so existing regression cases keep working.
@@ -176,7 +176,7 @@ The reusable `action.yml` calls the same CLI/core. There is no separate hosted a
 
 ## Mock and Probe Boundaries
 
-The current mock detector is structural. It recognizes explicit Python patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, then checks whether the target matches a changed function or class. That produces a **candidate signal**; it does not prove that the mock is wrong.
+The current mock detector uses a lightweight Python semantic layer before matching. It recognizes explicit patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, resolves common import aliases, preserves class/method qualified names, and normalizes common `src/` layouts before comparing a mock target with changed symbols. Unresolved dynamic targets stay conservative. A `PTG005` result is still a **candidate signal**; symbol identity does not prove that a mock is inappropriate.
 
 The targeted probe generator is deliberately limited. It covers a small set of status-code changes, boolean return flips, and comparison-boundary changes on lines added by the current PR. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
 
@@ -224,19 +224,19 @@ Version `0.1.0` supports direct Python/pytest PR analysis from the current Git r
 - uncovered changed Python lines when a coverage XML report is supplied;
 - obvious weak assertions added in changed tests;
 - suspicious test deletion, skip/xfail, or assertion removal;
-- structural mock targets that overlap changed Python symbols;
+- lightweight symbol-resolved mock targets that overlap changed Python symbols;
 - optional bounded targeted probes that survive an explicit test command.
 
 It still does **not** include:
 
 - configurable merge-blocking enforcement;
 - per-test coverage mapping;
-- broad semantic assertion or mock classification;
+- broad business-intent assertion or mock classification;
 - automatic discovery of every repository's test command;
 - safe privileged execution of untrusted PR code;
 - GitHub API ingestion or a hosted service.
 
-The next milestone is real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures before expanding the rule set.
+The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures. PTG005 now resolves common Python symbol/alias relationships first; later work can focus on bounded dependency relationships only where identity resolution is insufficient.
 
 ## License
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,19 @@ Version `0.1.0` is the first public-ready shape: direct real-PR checking, adviso
 
 The fixture runner is development infrastructure for the tool. It is not the product's public benchmark identity.
 
+## Current Main: PTG005 Semantic Lite
+
+The first post-`0.1.0` precision pass keeps PTG005 deterministic and offline while resolving common Python symbol identity before emitting mock-boundary candidates:
+
+- preserve class/method qualified names instead of matching only bare method names;
+- resolve common `import` / `from ... import ... as ...` aliases used by `patch.object`;
+- resolve standard relative imports;
+- normalize common `src/` package layouts;
+- suppress resolved same-name symbols when their canonical identities differ;
+- keep dynamic/unresolved targets conservative rather than guessing.
+
+This layer improves **identity precision**, not business-intent understanding. It still does not decide whether a mock is appropriate; PTG005 remains advisory. Real-PR dogfooding should measure whether the change removes recurring false positives without losing obvious changed-symbol mock cases.
+
 ## Product Principles
 
 ### Lightweight first
@@ -58,7 +71,7 @@ Priority cases:
 
 - pure refactors with no test changes;
 - existing tests that already cover changed code;
-- legitimate mocks around changed paths;
+- legitimate mocks around changed paths, especially same-name symbols and import aliases;
 - strong assertions that look syntactically simple;
 - test deletion/skip changes with explicit intent;
 - changed code with good coverage but a surviving targeted probe.
@@ -85,9 +98,9 @@ After the GitHub/Python path is stable, consider:
 - GitLab or other CI wrappers;
 - broader but still conservative mock/assertion analysis.
 
-## Optional Semantic Assistance
+## Optional Deeper Semantic Assistance
 
-Only after deterministic rules are useful on their own, consider optional semantic assistance for ambiguous mappings.
+Only after deterministic symbol resolution and bounded rule logic are useful on their own, consider optional semantic assistance for ambiguous business-intent mappings.
 
 It should remain:
 

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from .finding import Finding
+from .mock_analysis import collect_changed_symbols, extract_mock_targets, match_mock_target
 
 
 PROBE_REPLACEMENTS: tuple[tuple[str, str, str], ...] = (
@@ -437,70 +438,6 @@ def call_name(node: ast.AST) -> str | None:
     return dotted_name(node.func) if isinstance(node, ast.Call) else None
 
 
-def collect_changed_symbols(
-    repo_root: Path,
-    changed: dict[str, list[dict[str, Any]]],
-) -> list[dict[str, Any]]:
-    symbols: list[dict[str, Any]] = []
-    for rel_path, line_items in changed.items():
-        path = repo_root / rel_path
-        if not path.is_file() or path.suffix != ".py":
-            continue
-        try:
-            source = path.read_text(encoding="utf-8")
-            tree = ast.parse(source)
-        except (OSError, SyntaxError, UnicodeDecodeError):
-            continue
-        changed_lines = {item["line"] for item in line_items}
-        module_name = rel_path.removesuffix(".py").replace("/", ".")
-        short_module = Path(rel_path).stem
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                continue
-            start = getattr(node, "lineno", None)
-            end = getattr(node, "end_lineno", start)
-            if start is None or end is None or not any(start <= line <= end for line in changed_lines):
-                continue
-            symbols.append(
-                {
-                    "file": rel_path,
-                    "name": node.name,
-                    "line": start,
-                    "candidate_targets": sorted({node.name, f"{short_module}.{node.name}", f"{module_name}.{node.name}"}),
-                }
-            )
-    return symbols
-
-
-def extract_mock_target(source: str, node: ast.Call) -> tuple[str | None, str | None]:
-    name = call_name(node)
-    if not name:
-        return None, None
-    if name.endswith("patch.object") and len(node.args) >= 2:
-        attr = node.args[1]
-        if isinstance(attr, ast.Constant) and isinstance(attr.value, str):
-            return f"{source_for_node(source, node.args[0])}.{attr.value}", "patch.object"
-    if name == "patch" or name.endswith(".patch"):
-        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
-            return node.args[0].value, "patch"
-    if name.endswith(".setattr") and len(node.args) >= 2:
-        if isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
-            return node.args[0].value, "setattr"
-        if isinstance(node.args[1], ast.Constant) and isinstance(node.args[1].value, str):
-            return f"{source_for_node(source, node.args[0])}.{node.args[1].value}", "setattr"
-    return None, None
-
-
-def mock_matches(target: str, candidates: list[str]) -> bool:
-    normalized = target.strip("'\"")
-    return any(
-        normalized == candidate
-        or normalized.endswith(f".{candidate}")
-        or candidate.endswith(f".{normalized}")
-        for candidate in candidates
-    )
-
-
 def tracked_test_files(repo_root: Path) -> list[str]:
     result = run_command(["git", "ls-files", "*.py"], repo_root, check=True)
     return [line for line in result.stdout.splitlines() if line and is_test_path(line)]
@@ -524,30 +461,31 @@ def mock_boundary_findings(
             tree = ast.parse(source)
         except (OSError, SyntaxError, UnicodeDecodeError):
             continue
-        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
-            target, style = extract_mock_target(source, call)
-            if not target or not style:
+        for target in extract_mock_targets(source, tree, rel_path):
+            matches = match_mock_target(target, symbols)
+            if not matches:
                 continue
-            matched = [symbol for symbol in symbols if mock_matches(target, symbol["candidate_targets"])]
-            if not matched:
-                continue
-            key = (rel_path, call.lineno, target)
+            key = (rel_path, target.line, target.raw_target)
             if key in seen:
                 continue
             seen.add(key)
-            changed_names = ", ".join(sorted({item["name"] for item in matched}))
+            changed_names = ", ".join(sorted({item.symbol.canonical_name for item in matches}))
+            match_kinds = ", ".join(sorted({item.kind.value for item in matches}))
+            resolved = target.resolved_target or "unresolved"
             findings.append(
                 Finding(
                     rule_id="PTG005",
                     severity="warning",
                     file=rel_path,
-                    line=call.lineno,
-                    message="A test mocks a path that overlaps code changed by this PR; review whether the real changed behavior is still exercised.",
-                    evidence=f"{style} target={target}; changed symbol(s)={changed_names}",
+                    line=target.line,
+                    message="A resolved mock target overlaps code changed by this PR; review whether the real changed behavior is still exercised.",
+                    evidence=(
+                        f"{target.style} target={target.raw_target}; resolved={resolved}; "
+                        f"match={match_kinds}; changed symbol(s)={changed_names}"
+                    ),
                 )
             )
     return findings
-
 
 def generate_probes(
     changed: dict[str, list[dict[str, Any]]],

--- a/pr_test_guard/mock_analysis/__init__.py
+++ b/pr_test_guard/mock_analysis/__init__.py
@@ -1,0 +1,17 @@
+"""Lightweight Python semantic helpers for PTG005 mock-boundary checks."""
+
+from .matching import MatchKind, MockMatch, match_mock_target
+from .mocks import MockTarget, ResolutionKind, extract_mock_targets
+from .symbols import PythonSymbol, collect_changed_symbols, module_name_from_path
+
+__all__ = [
+    "MatchKind",
+    "MockMatch",
+    "MockTarget",
+    "PythonSymbol",
+    "ResolutionKind",
+    "collect_changed_symbols",
+    "extract_mock_targets",
+    "match_mock_target",
+    "module_name_from_path",
+]

--- a/pr_test_guard/mock_analysis/matching.py
+++ b/pr_test_guard/mock_analysis/matching.py
@@ -1,0 +1,55 @@
+"""Match resolved mock targets against changed Python symbols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .mocks import MockTarget, ResolutionKind
+from .symbols import PythonSymbol
+
+
+class MatchKind(str, Enum):
+    EXACT = "exact"
+    ALIAS_RESOLVED = "alias_resolved"
+    HEURISTIC = "heuristic"
+
+
+@dataclass(frozen=True, slots=True)
+class MockMatch:
+    target: MockTarget
+    symbol: PythonSymbol
+    kind: MatchKind
+
+
+def _canonical(value: str) -> str:
+    return value.strip().strip("'\"").strip(".")
+
+
+def _conservative_unresolved_match(raw_target: str, symbol: PythonSymbol) -> bool:
+    """Fallback only when semantic resolution is unavailable.
+
+    Require at least a module-qualified target plus the full symbol qualname.
+    A bare method/function name is intentionally insufficient because that was
+    a common source of same-name false positives in the original PTG005 rule.
+    """
+
+    raw = _canonical(raw_target)
+    if raw.count(".") < 1:
+        return False
+    suffix = f".{symbol.qualname}"
+    return raw == symbol.qualname or raw.endswith(suffix)
+
+
+def match_mock_target(target: MockTarget, symbols: list[PythonSymbol]) -> list[MockMatch]:
+    matches: list[MockMatch] = []
+    for symbol in symbols:
+        if target.resolved_target:
+            if _canonical(target.resolved_target) != _canonical(symbol.canonical_name):
+                continue
+            kind = MatchKind.ALIAS_RESOLVED if target.resolution == ResolutionKind.ALIAS else MatchKind.EXACT
+            matches.append(MockMatch(target=target, symbol=symbol, kind=kind))
+            continue
+        if _conservative_unresolved_match(target.raw_target, symbol):
+            matches.append(MockMatch(target=target, symbol=symbol, kind=MatchKind.HEURISTIC))
+    return matches

--- a/pr_test_guard/mock_analysis/mocks.py
+++ b/pr_test_guard/mock_analysis/mocks.py
@@ -1,0 +1,176 @@
+"""Extract and resolve explicit Python mock targets."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import PurePosixPath
+
+from .symbols import module_name_from_path
+
+
+class ResolutionKind(str, Enum):
+    LITERAL = "literal"
+    ALIAS = "alias_resolved"
+    QUALIFIED = "qualified"
+    UNRESOLVED = "unresolved"
+
+
+@dataclass(frozen=True, slots=True)
+class MockTarget:
+    raw_target: str
+    style: str
+    line: int
+    resolved_target: str | None
+    resolution: ResolutionKind
+
+
+def dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def call_name(node: ast.AST) -> str | None:
+    return dotted_name(node.func) if isinstance(node, ast.Call) else None
+
+
+def source_for_node(source: str, node: ast.AST) -> str:
+    return (ast.get_source_segment(source, node) or "").strip()
+
+
+def _package_for_module(rel_path: str, module: str) -> str:
+    if PurePosixPath(rel_path.replace("\\", "/")).name == "__init__.py":
+        return module
+    return module.rpartition(".")[0]
+
+
+def _resolve_from_module(current_package: str, module: str | None, level: int) -> str:
+    if level <= 0:
+        return module or ""
+    package_parts = [part for part in current_package.split(".") if part]
+    drop = max(0, level - 1)
+    if drop > len(package_parts):
+        return ""
+    base_parts = package_parts[: len(package_parts) - drop] if drop else package_parts
+    if module:
+        base_parts.extend(module.split("."))
+    return ".".join(base_parts)
+
+
+def build_import_table(tree: ast.AST, rel_path: str) -> dict[str, str]:
+    """Map local import names to deterministic qualified names."""
+
+    current_module = module_name_from_path(rel_path)
+    current_package = _package_for_module(rel_path, current_module)
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".")[0]
+                target = alias.name if alias.asname else alias.name.split(".")[0]
+                aliases[local] = target
+        elif isinstance(node, ast.ImportFrom):
+            base = _resolve_from_module(current_package, node.module, node.level)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local = alias.asname or alias.name
+                target = f"{base}.{alias.name}" if base else alias.name
+                aliases[local] = target
+    return aliases
+
+
+def resolve_dotted_target(raw_target: str, imports: dict[str, str]) -> tuple[str | None, ResolutionKind]:
+    raw = raw_target.strip().strip("'\"")
+    if not raw or "(" in raw or ")" in raw or "[" in raw or "]" in raw:
+        return None, ResolutionKind.UNRESOLVED
+    parts = raw.split(".")
+    first = parts[0]
+    if first in imports:
+        resolved = ".".join([imports[first], *parts[1:]])
+        return resolved, ResolutionKind.ALIAS
+    if len(parts) >= 2:
+        return raw, ResolutionKind.QUALIFIED
+    return None, ResolutionKind.UNRESOLVED
+
+
+def _resolved_call_name(node: ast.Call, imports: dict[str, str]) -> str | None:
+    raw = call_name(node)
+    if not raw:
+        return None
+    resolved, _ = resolve_dotted_target(raw, imports)
+    return resolved or raw
+
+
+def extract_mock_targets(source: str, tree: ast.AST, rel_path: str) -> list[MockTarget]:
+    """Extract supported mock/patch calls and resolve common aliases."""
+
+    imports = build_import_table(tree, rel_path)
+    targets: list[MockTarget] = []
+    for node in (item for item in ast.walk(tree) if isinstance(item, ast.Call)):
+        raw_call = call_name(node)
+        resolved_call = _resolved_call_name(node, imports)
+        if not raw_call or not resolved_call:
+            continue
+
+        style: str | None = None
+        raw_target: str | None = None
+        resolved_target: str | None = None
+        resolution = ResolutionKind.UNRESOLVED
+
+        is_patch_object = raw_call.endswith("patch.object") or resolved_call.endswith("unittest.mock.patch.object")
+        is_patch = (
+            raw_call == "patch"
+            or raw_call.endswith(".patch")
+            or resolved_call == "unittest.mock.patch"
+            or resolved_call.endswith(".mocker.patch")
+        )
+        is_setattr = raw_call.endswith(".setattr")
+
+        if is_patch_object and len(node.args) >= 2:
+            attr = node.args[1]
+            if isinstance(attr, ast.Constant) and isinstance(attr.value, str):
+                owner = dotted_name(node.args[0])
+                if owner:
+                    raw_target = f"{owner}.{attr.value}"
+                    resolved_target, resolution = resolve_dotted_target(raw_target, imports)
+                else:
+                    raw_target = f"{source_for_node(source, node.args[0])}.{attr.value}"
+                style = "patch.object"
+        elif is_patch and node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            raw_target = node.args[0].value
+            resolved_target = raw_target.strip().strip("'\"")
+            resolution = ResolutionKind.LITERAL
+            style = "patch"
+        elif is_setattr and len(node.args) >= 2:
+            first, second = node.args[0], node.args[1]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                raw_target = first.value
+                resolved_target = raw_target.strip().strip("'\"")
+                resolution = ResolutionKind.LITERAL
+                style = "setattr"
+            elif isinstance(second, ast.Constant) and isinstance(second.value, str):
+                owner = dotted_name(first)
+                if owner:
+                    raw_target = f"{owner}.{second.value}"
+                    resolved_target, resolution = resolve_dotted_target(raw_target, imports)
+                else:
+                    raw_target = f"{source_for_node(source, first)}.{second.value}"
+                style = "setattr"
+
+        if raw_target and style:
+            targets.append(
+                MockTarget(
+                    raw_target=raw_target,
+                    style=style,
+                    line=node.lineno,
+                    resolved_target=resolved_target,
+                    resolution=resolution,
+                )
+            )
+    return targets

--- a/pr_test_guard/mock_analysis/symbols.py
+++ b/pr_test_guard/mock_analysis/symbols.py
@@ -1,0 +1,104 @@
+"""Lightweight Python symbol resolution for mock-boundary analysis."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class PythonSymbol:
+    """A Python symbol changed by the current PR."""
+
+    file: str
+    module: str
+    qualname: str
+    name: str
+    line: int
+
+    @property
+    def canonical_name(self) -> str:
+        return f"{self.module}.{self.qualname}" if self.module else self.qualname
+
+
+def module_name_from_path(rel_path: str) -> str:
+    """Convert a repository-relative Python path to its common import name.
+
+    The resolver intentionally handles only deterministic layout conventions.
+    In particular, ``src/foo/bar.py`` maps to ``foo.bar`` rather than
+    ``src.foo.bar``.  Projects with custom import hooks remain unresolved
+    rather than being guessed.
+    """
+
+    path = PurePosixPath(rel_path.replace("\\", "/"))
+    parts = list(path.parts)
+    if parts and parts[0] == "src":
+        parts = parts[1:]
+    if not parts or not parts[-1].endswith(".py"):
+        return ""
+    stem = parts[-1][:-3]
+    parts[-1] = stem
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(part for part in parts if part)
+
+
+class _ChangedSymbolCollector(ast.NodeVisitor):
+    def __init__(self, module: str, rel_path: str, changed_lines: set[int]) -> None:
+        self.module = module
+        self.rel_path = rel_path
+        self.changed_lines = changed_lines
+        self.scope: list[str] = []
+        self.symbols: list[PythonSymbol] = []
+
+    def _visit_symbol(self, node: ast.AST, name: str) -> None:
+        start = getattr(node, "lineno", None)
+        end = getattr(node, "end_lineno", start)
+        if start is not None and end is not None and any(start <= line <= end for line in self.changed_lines):
+            qualname = ".".join([*self.scope, name])
+            self.symbols.append(
+                PythonSymbol(
+                    file=self.rel_path,
+                    module=self.module,
+                    qualname=qualname,
+                    name=name,
+                    line=start,
+                )
+            )
+        self.scope.append(name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802 - ast visitor API
+        self._visit_symbol(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802 - ast visitor API
+        self._visit_symbol(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802 - ast visitor API
+        self._visit_symbol(node, node.name)
+
+
+def collect_changed_symbols(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+) -> list[PythonSymbol]:
+    """Collect changed classes/functions with lexical qualified names."""
+
+    symbols: list[PythonSymbol] = []
+    for rel_path, line_items in changed.items():
+        path = repo_root / rel_path
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        changed_lines = {int(item["line"]) for item in line_items}
+        collector = _ChangedSymbolCollector(module_name_from_path(rel_path), rel_path, changed_lines)
+        collector.visit(tree)
+        symbols.extend(collector.symbols)
+    return symbols

--- a/tests/test_mock_semantic.py
+++ b/tests/test_mock_semantic.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pr_test_guard.check import analyze_repository
+
+
+def run(*args: str, cwd: Path) -> None:
+    subprocess.run(list(args), cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run("git", "init", "-b", "main", cwd=repo)
+    run("git", "config", "user.name", "Test User", cwd=repo)
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    return repo
+
+
+def commit_all(repo: Path, message: str) -> None:
+    run("git", "add", "-A", cwd=repo)
+    run("git", "commit", "-m", message, cwd=repo)
+
+
+def ptg005(result):
+    return [item for item in result.findings if item.rule_id == "PTG005"]
+
+
+def test_patch_object_import_alias_resolves_changed_method(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "src/payment/service.py",
+        "class PaymentService:\n    def charge(self, amount):\n        return amount > 0\n",
+    )
+    write(repo / "tests/test_payment.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "src/payment/service.py",
+        "class PaymentService:\n    def charge(self, amount):\n        return amount >= 0\n",
+    )
+    write(
+        repo / "tests/test_payment.py",
+        "from unittest.mock import patch\n"
+        "from payment.service import PaymentService as Service\n\n"
+        "@patch.object(Service, 'charge')\n"
+        "def test_charge(mock_charge):\n    assert mock_charge is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "resolved=payment.service.PaymentService.charge" in (findings[0].evidence or "")
+    assert "match=alias_resolved" in (findings[0].evidence or "")
+
+
+def test_same_method_name_on_different_class_is_not_matched(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "services.py",
+        "class PaymentService:\n    def run(self):\n        return 'pay'\n\n"
+        "class EmailService:\n    def run(self):\n        return 'mail'\n",
+    )
+    write(repo / "tests/test_services.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "services.py",
+        "class PaymentService:\n    def run(self):\n        return 'paid'\n\n"
+        "class EmailService:\n    def run(self):\n        return 'mail'\n",
+    )
+    write(
+        repo / "tests/test_services.py",
+        "from unittest.mock import patch\nfrom services import EmailService\n\n"
+        "@patch.object(EmailService, 'run')\n"
+        "def test_email(mock_run):\n    assert mock_run is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))
+
+
+def test_same_function_name_in_different_module_is_not_matched(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "payment.py", "def send():\n    return 'pay'\n")
+    write(repo / "email.py", "def send():\n    return 'mail'\n")
+    write(repo / "tests/test_send.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(repo / "payment.py", "def send():\n    return 'paid'\n")
+    write(
+        repo / "tests/test_send.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('email.send')\n"
+        "def test_email(mock_send):\n    assert mock_send is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))
+
+
+def test_src_layout_uses_importable_module_name(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "src/foo/service.py", "def charge(amount):\n    return amount > 0\n")
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(repo / "src/foo/service.py", "def charge(amount):\n    return amount >= 0\n")
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('foo.service.charge')\n"
+        "def test_charge(mock_charge):\n    assert mock_charge is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "changed symbol(s)=foo.service.charge" in (findings[0].evidence or "")
+
+
+def test_module_alias_resolves_patch_object_owner(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "src/foo/service.py",
+        "class PaymentService:\n    def charge(self):\n        return False\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "src/foo/service.py",
+        "class PaymentService:\n    def charge(self):\n        return True\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\nimport foo.service as service_module\n\n"
+        "@patch.object(service_module.PaymentService, 'charge')\n"
+        "def test_charge(mock_charge):\n    assert mock_charge is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert len(ptg005(analyze_repository(repo, base="HEAD~1"))) == 1
+
+
+def test_relative_import_alias_resolves_patch_object_owner(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "foo/__init__.py", "")
+    write(repo / "foo/tests/__init__.py", "")
+    write(
+        repo / "foo/service.py",
+        "class PaymentService:\n    def charge(self):\n        return False\n",
+    )
+    write(repo / "foo/tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "foo/service.py",
+        "class PaymentService:\n    def charge(self):\n        return True\n",
+    )
+    write(
+        repo / "foo/tests/test_service.py",
+        "from unittest.mock import patch\nfrom ..service import PaymentService\n\n"
+        "@patch.object(PaymentService, 'charge')\n"
+        "def test_charge(mock_charge):\n    assert mock_charge is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "resolved=foo.service.PaymentService.charge" in (findings[0].evidence or "")
+
+
+def test_dynamic_patch_object_owner_is_left_unresolved(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "service.py", "class Service:\n    def run(self):\n        return False\n")
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(repo / "service.py", "class Service:\n    def run(self):\n        return True\n")
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "def get_service():\n    return object()\n\n"
+        "@patch.object(get_service(), 'run')\n"
+        "def test_run(mock_run):\n    assert mock_run is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))


### PR DESCRIPTION
Improves PTG005 precision with a lightweight, deterministic Python semantic layer. The checker now preserves class/method qualified names, resolves common import aliases and relative imports, normalizes src-layout module names, and keeps unresolved dynamic mock targets conservative. Adds regression coverage for same-name symbol false positives without introducing an LLM or new runtime dependencies. Version remains 0.1.0; release preparation can follow separately after real-PR validation.