### PR TITLE
Classify mock relationships around changed Python behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The direct `check` command currently emits six PR-scoped rule families:
 | `PTG002` | A changed Python line is uncovered in the supplied coverage XML. |
 | `PTG003` | A newly added assertion has an obviously weak existence/truthiness shape. |
 | `PTG004` | A test was deleted, skipped/xfail-marked, or lost assertions. |
-| `PTG005` | A resolved Python mock target overlaps a symbol changed by the PR, with conservative handling of unresolved cases. |
+| `PTG005` | A mock directly replaces a changed Python symbol, or a changed test mocks an internal dependency called on a changed production line. |
 | `PTG006` | An opt-in bounded targeted probe survives the configured tests. |
 
 These are review-oriented signals. Heuristic findings such as `PTG003` and `PTG005` are advisory by default rather than automatic reasons to block a merge. The older fixture runner retains its research-prototype labels internally so existing regression cases keep working.
@@ -176,7 +176,7 @@ The reusable `action.yml` calls the same CLI/core. There is no separate hosted a
 
 ## Mock and Probe Boundaries
 
-The current mock detector uses a lightweight Python semantic layer before matching. It recognizes explicit patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, resolves common import aliases, preserves class/method qualified names, and normalizes common `src/` layouts before comparing a mock target with changed symbols. Unresolved dynamic targets stay conservative. A `PTG005` result is still a **candidate signal**; symbol identity does not prove that a mock is inappropriate.
+The current mock detector uses a lightweight Python semantic layer before matching. It recognizes explicit patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, resolves common import aliases, preserves class/method qualified names, and normalizes common `src/` layouts. It then adds a bounded relationship pass: direct changed-symbol mocks remain visible, while mocks in tests changed by the PR can also be related to **direct internal dependencies whose call sites are themselves changed by the PR**. Explicit imported dependencies that resolve outside the repository are treated as external-boundary candidates and suppressed from PTG005 warnings. Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural relationship evidence does not prove that a mock is inappropriate.
 
 The targeted probe generator is deliberately limited. It covers a small set of status-code changes, boolean return flips, and comparison-boundary changes on lines added by the current PR. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
 
@@ -224,7 +224,7 @@ Version `0.1.0` supports direct Python/pytest PR analysis from the current Git r
 - uncovered changed Python lines when a coverage XML report is supplied;
 - obvious weak assertions added in changed tests;
 - suspicious test deletion, skip/xfail, or assertion removal;
-- lightweight symbol-resolved mock targets that overlap changed Python symbols;
+- lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites;
 - optional bounded targeted probes that survive an explicit test command.
 
 It still does **not** include:
@@ -236,7 +236,7 @@ It still does **not** include:
 - safe privileged execution of untrusted PR code;
 - GitHub API ingestion or a hosted service.
 
-The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures. PTG005 now resolves common Python symbol/alias relationships first; later work can focus on bounded dependency relationships only where identity resolution is insufficient.
+The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures. PTG005 now combines symbol identity with a deliberately bounded direct-dependency pass; later work should focus on real-PR precision, related-test selection, and only then optional deeper semantic assistance where deterministic relationships remain ambiguous.
 
 ## License
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -73,7 +73,7 @@ The direct checker uses six stable rule ids for the current Python/pytest scope:
 - `PTG002` — changed Python line uncovered in a supplied coverage XML;
 - `PTG003` — possible weak assertion added in a changed test;
 - `PTG004` — suspicious test deletion, skip/xfail, or assertion removal;
-- `PTG005` — structural mock target overlaps a changed Python symbol;
+- `PTG005` — a mock directly replaces a changed Python symbol, or a changed test mocks an internal dependency called on a changed production line;
 - `PTG006` — bounded targeted probe survives the configured tests.
 
 Each result includes a rule id, advisory severity, file/line where available, a short message, and evidence text. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -36,7 +36,7 @@ The current Python/pytest path uses:
 - changed production and test files;
 - changed Python lines;
 - changed test assertions and skip/xfail markers;
-- tracked Python tests for structural mock-boundary candidates;
+- tracked Python tests for symbol-resolved mock targets and bounded changed-call relationships;
 - optional `coverage.py` XML;
 - optional explicit test command for bounded targeted probes.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,16 +21,28 @@ The fixture runner is development infrastructure for the tool. It is not the pro
 
 ## Current Main: PTG005 Semantic Lite
 
-The first post-`0.1.0` precision pass keeps PTG005 deterministic and offline while resolving common Python symbol identity before emitting mock-boundary candidates:
+The post-`0.1.0` PTG005 precision work remains deterministic and offline, but now has two bounded layers.
+
+**Identity resolution**:
 
 - preserve class/method qualified names instead of matching only bare method names;
 - resolve common `import` / `from ... import ... as ...` aliases used by `patch.object`;
 - resolve standard relative imports;
 - normalize common `src/` package layouts;
 - suppress resolved same-name symbols when their canonical identities differ;
-- keep dynamic/unresolved targets conservative rather than guessing.
+- keep dynamic/unresolved targets conservative rather than guessing;
+- avoid treating a class container as changed merely because one of its methods changed.
 
-This layer improves **identity precision**, not business-intent understanding. It still does not decide whether a mock is appropriate; PTG005 remains advisory. Real-PR dogfooding should measure whether the change removes recurring false positives without losing obvious changed-symbol mock cases.
+**Changed-call relationships**:
+
+- keep direct changed-symbol mocks as the highest-confidence PTG005 candidate;
+- inspect only direct calls whose call sites are on lines changed by the PR;
+- only expand indirect PTG005 warnings to tests that are also changed by the PR;
+- recognize direct internal dependencies and report that relationship explicitly;
+- recognize explicitly imported external dependencies and suppress those external-boundary candidates;
+- keep unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved relationships out of the warning path.
+
+This layer improves **structural relationship precision**, not business-intent understanding. It still does not decide whether a mock is appropriate, build a repository-wide call graph, or infer dynamic Python types. PTG005 remains advisory. Real-PR dogfooding should measure whether the relationship layer removes low-value warnings while retaining direct changed-symbol and changed-internal-dependency cases.
 
 ## Product Principles
 
@@ -71,7 +83,7 @@ Priority cases:
 
 - pure refactors with no test changes;
 - existing tests that already cover changed code;
-- legitimate mocks around changed paths, especially same-name symbols and import aliases;
+- legitimate mocks around changed paths, especially external SDK/API boundaries and internal helpers;
 - strong assertions that look syntactically simple;
 - test deletion/skip changes with explicit intent;
 - changed code with good coverage but a surviving targeted probe.

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -14,7 +14,14 @@ from pathlib import Path
 from typing import Any
 
 from .finding import Finding
-from .mock_analysis import collect_changed_symbols, extract_mock_targets, match_mock_target
+from .mock_analysis import (
+    MockRelation,
+    classify_dependency_relation,
+    collect_changed_dependency_calls,
+    collect_changed_symbols,
+    extract_mock_targets,
+    match_mock_target,
+)
 
 
 PROBE_REPLACEMENTS: tuple[tuple[str, str, str], ...] = (
@@ -438,21 +445,40 @@ def call_name(node: ast.AST) -> str | None:
     return dotted_name(node.func) if isinstance(node, ast.Call) else None
 
 
-def tracked_test_files(repo_root: Path) -> list[str]:
+def tracked_python_files(repo_root: Path) -> list[str]:
     result = run_command(["git", "ls-files", "*.py"], repo_root, check=True)
-    return [line for line in result.stdout.splitlines() if line and is_test_path(line)]
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def tracked_test_files(repo_root: Path) -> list[str]:
+    return [line for line in tracked_python_files(repo_root) if is_test_path(line)]
 
 
 def mock_boundary_findings(
     repo_root: Path,
     changed: dict[str, list[dict[str, Any]]],
+    files: list[FileDiff],
+    notes: list[str],
 ) -> list[Finding]:
     symbols = collect_changed_symbols(repo_root, changed)
     if not symbols:
         return []
+
+    python_files = tracked_python_files(repo_root)
+    production_python_files = [path for path in python_files if not is_test_path(path)]
+    dependencies = collect_changed_dependency_calls(
+        repo_root,
+        changed,
+        symbols,
+        tracked_python_paths=production_python_files,
+    )
+    changed_test_files = {item.path for item in files if is_test_path(item.path) and item.status != "D"}
+
     findings: list[Finding] = []
     seen: set[tuple[str, int, str]] = set()
-    for rel_path in tracked_test_files(repo_root):
+    suppressed_external = 0
+
+    for rel_path in (line for line in python_files if is_test_path(line)):
         path = repo_root / rel_path
         if not path.is_file():
             continue
@@ -461,30 +487,84 @@ def mock_boundary_findings(
             tree = ast.parse(source)
         except (OSError, SyntaxError, UnicodeDecodeError):
             continue
+
         for target in extract_mock_targets(source, tree, rel_path):
-            matches = match_mock_target(target, symbols)
-            if not matches:
-                continue
             key = (rel_path, target.line, target.raw_target)
             if key in seen:
                 continue
+
+            direct_matches = match_mock_target(target, symbols)
+            if direct_matches:
+                seen.add(key)
+                changed_names = ", ".join(sorted({item.symbol.canonical_name for item in direct_matches}))
+                match_kinds = ", ".join(sorted({item.kind.value for item in direct_matches}))
+                resolved = target.resolved_target or "unresolved"
+                findings.append(
+                    Finding(
+                        rule_id="PTG005",
+                        severity="warning",
+                        file=rel_path,
+                        line=target.line,
+                        message=(
+                            "A mock directly replaces a Python symbol changed by this PR; "
+                            "review whether the real changed behavior is still exercised."
+                        ),
+                        evidence=(
+                            f"relation={MockRelation.DIRECT_CHANGED_SYMBOL.value}; "
+                            f"{target.style} target={target.raw_target}; resolved={resolved}; "
+                            f"match={match_kinds}; changed symbol(s)={changed_names}"
+                        ),
+                    )
+                )
+                continue
+
+            # Relationship expansion is deliberately narrower than direct symbol
+            # matching: only mocks in tests changed by this PR are considered,
+            # and only dependencies called on changed production lines qualify.
+            # This prevents v2 from surfacing a backlog of old mocks in untouched
+            # tests just because a production function changed.
+            if rel_path not in changed_test_files:
+                continue
+
+            relationship = classify_dependency_relation(target, dependencies)
+            if relationship.relation == MockRelation.EXTERNAL_BOUNDARY:
+                suppressed_external += 1
+                seen.add(key)
+                continue
+            if relationship.relation != MockRelation.DIRECT_INTERNAL_DEPENDENCY:
+                continue
+
+            dependency = relationship.dependency
+            owner = relationship.changed_symbol
+            if dependency is None or owner is None:
+                continue
             seen.add(key)
-            changed_names = ", ".join(sorted({item.symbol.canonical_name for item in matches}))
-            match_kinds = ", ".join(sorted({item.kind.value for item in matches}))
             resolved = target.resolved_target or "unresolved"
+            dependency_targets = ", ".join(dependency.candidate_targets)
             findings.append(
                 Finding(
                     rule_id="PTG005",
                     severity="warning",
                     file=rel_path,
                     line=target.line,
-                    message="A resolved mock target overlaps code changed by this PR; review whether the real changed behavior is still exercised.",
+                    message=(
+                        "A changed test mocks an internal dependency called on a line changed by this PR; "
+                        "review whether the changed behavior is still exercised."
+                    ),
                     evidence=(
+                        f"relation={MockRelation.DIRECT_INTERNAL_DEPENDENCY.value}; "
                         f"{target.style} target={target.raw_target}; resolved={resolved}; "
-                        f"match={match_kinds}; changed symbol(s)={changed_names}"
+                        f"changed symbol={owner.canonical_name}; changed call line={dependency.line}; "
+                        f"dependency target(s)={dependency_targets}"
                     ),
                 )
             )
+
+    if suppressed_external:
+        notes.append(
+            "PTG005: suppressed "
+            f"{suppressed_external} external-boundary mock candidate(s) on changed call sites."
+        )
     return findings
 
 def generate_probes(
@@ -620,7 +700,7 @@ def analyze_repository(
     findings.extend(uncovered_line_findings(repo_root, changed, coverage_path, notes))
     findings.extend(weak_assertion_findings(repo_root, files))
     findings.extend(test_weakening_findings(repo_root, files))
-    findings.extend(mock_boundary_findings(repo_root, changed))
+    findings.extend(mock_boundary_findings(repo_root, changed, files, notes))
     probe_findings, probe_summary = targeted_probe_findings(
         repo_root,
         changed,

--- a/pr_test_guard/mock_analysis/__init__.py
+++ b/pr_test_guard/mock_analysis/__init__.py
@@ -2,14 +2,28 @@
 
 from .matching import MatchKind, MockMatch, match_mock_target
 from .mocks import MockTarget, ResolutionKind, extract_mock_targets
+from .relations import (
+    DependencyCall,
+    MockRelation,
+    OwnershipKind,
+    RelationshipMatch,
+    classify_dependency_relation,
+    collect_changed_dependency_calls,
+)
 from .symbols import PythonSymbol, collect_changed_symbols, module_name_from_path
 
 __all__ = [
+    "DependencyCall",
     "MatchKind",
     "MockMatch",
+    "MockRelation",
     "MockTarget",
+    "OwnershipKind",
     "PythonSymbol",
+    "RelationshipMatch",
     "ResolutionKind",
+    "classify_dependency_relation",
+    "collect_changed_dependency_calls",
     "collect_changed_symbols",
     "extract_mock_targets",
     "match_mock_target",

--- a/pr_test_guard/mock_analysis/relations.py
+++ b/pr_test_guard/mock_analysis/relations.py
@@ -1,0 +1,373 @@
+"""Bounded changed-call relationship analysis for PTG005.
+
+The module intentionally stops at direct call sites that are themselves changed by
+this PR.  It does not try to build a whole-repository call graph or infer dynamic
+Python types.  The goal is to add a small amount of relationship evidence without
+turning PTG005 into a general static-analysis engine.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+from .mocks import MockTarget, build_import_table, dotted_name, resolve_dotted_target
+from .symbols import PythonSymbol, module_name_from_path
+
+
+class OwnershipKind(str, Enum):
+    INTERNAL = "internal"
+    EXTERNAL = "external"
+    UNKNOWN = "unknown"
+
+
+class MockRelation(str, Enum):
+    DIRECT_CHANGED_SYMBOL = "direct_changed_symbol"
+    DIRECT_INTERNAL_DEPENDENCY = "direct_internal_dependency"
+    EXTERNAL_BOUNDARY = "external_boundary"
+    UNRELATED = "unrelated"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCall:
+    """One direct call on a line added by the current PR."""
+
+    owner: PythonSymbol
+    raw_target: str
+    line: int
+    candidate_targets: tuple[str, ...]
+    ownership: OwnershipKind
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipMatch:
+    relation: MockRelation
+    target: MockTarget
+    changed_symbol: PythonSymbol | None = None
+    dependency: DependencyCall | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RepoModuleIndex:
+    modules: frozenset[str]
+
+    @classmethod
+    def from_paths(cls, paths: Iterable[str]) -> "RepoModuleIndex":
+        modules = {
+            module_name_from_path(path)
+            for path in paths
+            if path.endswith(".py") and module_name_from_path(path)
+        }
+        return cls(frozenset(modules))
+
+    def owns_target(self, target: str) -> bool:
+        normalized = _canonical(target)
+        if not normalized:
+            return False
+        # A canonical symbol can continue below the module path with class and
+        # member names, so match the longest tracked module prefix.
+        return any(normalized == module or normalized.startswith(f"{module}.") for module in self.modules)
+
+
+def _canonical(value: str) -> str:
+    return value.strip().strip("'\"").strip(".")
+
+
+def _node_span(node: ast.AST) -> tuple[int, int] | None:
+    start = getattr(node, "lineno", None)
+    end = getattr(node, "end_lineno", start)
+    if start is None or end is None:
+        return None
+    return int(start), int(end)
+
+
+def _intersects_changed_lines(node: ast.AST, changed_lines: set[int]) -> bool:
+    span = _node_span(node)
+    if span is None:
+        return False
+    start, end = span
+    return any(start <= line <= end for line in changed_lines)
+
+
+def _top_level_definitions(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            names.add(node.name)
+    return names
+
+
+def _owner_class_qualname(symbol: PythonSymbol) -> str | None:
+    if "." not in symbol.qualname:
+        return None
+    return symbol.qualname.rsplit(".", 1)[0]
+
+
+def _resolve_call_candidates(
+    raw_target: str,
+    *,
+    module: str,
+    owner: PythonSymbol,
+    imports: dict[str, str],
+    local_definitions: set[str],
+) -> tuple[str, ...]:
+    """Resolve a call conservatively to lookup and definition identities.
+
+    For imported names, Python mocks are commonly applied where a name is
+    looked up (for example ``service.calculate_retry``) rather than only where
+    it was originally defined (``retry.calculate_retry``).  Keep both forms so
+    relationship matching follows real-world patching practice.
+    """
+
+    raw = _canonical(raw_target)
+    if not raw or "(" in raw or ")" in raw or "[" in raw or "]" in raw:
+        return ()
+
+    parts = raw.split(".")
+    first = parts[0]
+    candidates: list[str] = []
+
+    if first in {"self", "cls"}:
+        class_qualname = _owner_class_qualname(owner)
+        # ``self.method()`` is deterministic enough for a lexical class-method
+        # relationship.  Deeper chains such as ``self.gateway.send()`` require
+        # instance-attribute type inference and intentionally remain unresolved.
+        if not class_qualname or len(parts) != 2:
+            return ()
+        candidates.append(".".join([module, class_qualname, parts[1]]).strip("."))
+        return tuple(dict.fromkeys(item for item in candidates if item))
+
+    if first in imports:
+        resolved, _ = resolve_dotted_target(raw, imports)
+        if resolved:
+            candidates.append(resolved)
+        # Preserve the module-local lookup identity as well.  This catches the
+        # canonical "patch where looked up" form for imported functions/modules.
+        if module:
+            candidates.append(f"{module}.{raw}")
+        return tuple(dict.fromkeys(_canonical(item) for item in candidates if item))
+
+    if first in local_definitions:
+        candidates.append(f"{module}.{raw}" if module else raw)
+        return tuple(dict.fromkeys(_canonical(item) for item in candidates if item))
+
+    # A bare unresolved name may be a builtin, closure, dynamically assigned
+    # callable, or global.  A dotted name whose root is not an import/local
+    # definition may be an instance attribute.  Do not guess either case.
+    return ()
+
+
+class _ChangedCallCollector(ast.NodeVisitor):
+    """Collect calls while refusing to descend into nested definitions."""
+
+    def __init__(
+        self,
+        *,
+        owner: PythonSymbol,
+        module: str,
+        imports: dict[str, str],
+        local_definitions: set[str],
+        changed_lines: set[int],
+        module_index: RepoModuleIndex,
+    ) -> None:
+        self.owner = owner
+        self.module = module
+        self.imports = imports
+        self.local_definitions = local_definitions
+        self.changed_lines = changed_lines
+        self.module_index = module_index
+        self.calls: list[DependencyCall] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        return None
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        return None
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        return None
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        if _intersects_changed_lines(node, self.changed_lines):
+            raw = dotted_name(node.func)
+            if raw:
+                candidates = _resolve_call_candidates(
+                    raw,
+                    module=self.module,
+                    owner=self.owner,
+                    imports=self.imports,
+                    local_definitions=self.local_definitions,
+                )
+                if candidates:
+                    first = raw.split(".")[0]
+                    if first in {"self", "cls"} or first in self.local_definitions:
+                        ownership = OwnershipKind.INTERNAL
+                    elif first in self.imports:
+                        resolved, _ = resolve_dotted_target(raw, self.imports)
+                        ownership = (
+                            OwnershipKind.INTERNAL
+                            if resolved and self.module_index.owns_target(resolved)
+                            else OwnershipKind.EXTERNAL
+                        )
+                    else:
+                        ownership = OwnershipKind.UNKNOWN
+                    self.calls.append(
+                        DependencyCall(
+                            owner=self.owner,
+                            raw_target=raw,
+                            line=node.lineno,
+                            candidate_targets=candidates,
+                            ownership=ownership,
+                        )
+                    )
+        self.generic_visit(node)
+
+
+def _walk_symbol_nodes(tree: ast.Module) -> dict[str, ast.AST]:
+    """Index function/method definitions by lexical qualname."""
+
+    nodes: dict[str, ast.AST] = {}
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.scope: list[str] = []
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+            self.scope.append(node.name)
+            self.generic_visit(node)
+            self.scope.pop()
+
+        def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+            qualname = ".".join([*self.scope, node.name])
+            nodes[qualname] = node
+            self.scope.append(node.name)
+            self.generic_visit(node)
+            self.scope.pop()
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+            self._visit_function(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+            self._visit_function(node)
+
+    Visitor().visit(tree)
+    return nodes
+
+
+def collect_changed_dependency_calls(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+    symbols: list[PythonSymbol],
+    *,
+    tracked_python_paths: Iterable[str],
+) -> list[DependencyCall]:
+    """Collect direct dependencies on changed call sites inside changed functions.
+
+    Only call expressions that overlap added PR lines are considered.  Calls in
+    unchanged parts of a changed function are intentionally ignored because
+    relating those mocks to the current PR is more ambiguous and noisier.
+    """
+
+    by_file: dict[str, list[PythonSymbol]] = {}
+    for symbol in symbols:
+        by_file.setdefault(symbol.file, []).append(symbol)
+
+    module_index = RepoModuleIndex.from_paths(tracked_python_paths)
+    dependencies: list[DependencyCall] = []
+
+    for rel_path, line_items in changed.items():
+        file_symbols = by_file.get(rel_path, [])
+        if not file_symbols:
+            continue
+        path = repo_root / rel_path
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+
+        module = module_name_from_path(rel_path)
+        imports = build_import_table(tree, rel_path)
+        local_definitions = _top_level_definitions(tree)
+        changed_lines = {int(item["line"]) for item in line_items}
+        symbol_nodes = _walk_symbol_nodes(tree)
+
+        for symbol in file_symbols:
+            node = symbol_nodes.get(symbol.qualname)
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            collector = _ChangedCallCollector(
+                owner=symbol,
+                module=module,
+                imports=imports,
+                local_definitions=local_definitions,
+                changed_lines=changed_lines,
+                module_index=module_index,
+            )
+            for statement in node.body:
+                collector.visit(statement)
+            dependencies.extend(collector.calls)
+
+    # Preserve stable output while removing duplicate calls that can arise from
+    # overlapping changed-line spans in a multi-line call expression.
+    unique: dict[tuple[str, str, int, tuple[str, ...]], DependencyCall] = {}
+    for item in dependencies:
+        key = (item.owner.canonical_name, item.raw_target, item.line, item.candidate_targets)
+        unique[key] = item
+    return list(unique.values())
+
+
+def _target_candidates(target: MockTarget) -> tuple[str, ...]:
+    values = []
+    if target.resolved_target:
+        values.append(_canonical(target.resolved_target))
+    raw = _canonical(target.raw_target)
+    if raw and raw not in values:
+        values.append(raw)
+    return tuple(values)
+
+
+def classify_dependency_relation(
+    target: MockTarget,
+    dependencies: Iterable[DependencyCall],
+) -> RelationshipMatch:
+    candidates = set(_target_candidates(target))
+    if not candidates:
+        return RelationshipMatch(MockRelation.UNKNOWN, target)
+
+    matches = [
+        dependency
+        for dependency in dependencies
+        if candidates.intersection(dependency.candidate_targets)
+    ]
+    if not matches:
+        return RelationshipMatch(MockRelation.UNRELATED, target)
+
+    internal = [item for item in matches if item.ownership == OwnershipKind.INTERNAL]
+    if internal:
+        return RelationshipMatch(
+            MockRelation.DIRECT_INTERNAL_DEPENDENCY,
+            target,
+            changed_symbol=internal[0].owner,
+            dependency=internal[0],
+        )
+
+    external = [item for item in matches if item.ownership == OwnershipKind.EXTERNAL]
+    if external:
+        return RelationshipMatch(
+            MockRelation.EXTERNAL_BOUNDARY,
+            target,
+            changed_symbol=external[0].owner,
+            dependency=external[0],
+        )
+
+    return RelationshipMatch(
+        MockRelation.UNKNOWN,
+        target,
+        changed_symbol=matches[0].owner,
+        dependency=matches[0],
+    )

--- a/pr_test_guard/mock_analysis/symbols.py
+++ b/pr_test_guard/mock_analysis/symbols.py
@@ -53,10 +53,39 @@ class _ChangedSymbolCollector(ast.NodeVisitor):
         self.scope: list[str] = []
         self.symbols: list[PythonSymbol] = []
 
+    @staticmethod
+    def _nested_symbol_spans(node: ast.AST) -> list[tuple[int, int]]:
+        spans: list[tuple[int, int]] = []
+
+        def walk(current: ast.AST) -> None:
+            for child in ast.iter_child_nodes(current):
+                if isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                    start = getattr(child, "lineno", None)
+                    end = getattr(child, "end_lineno", start)
+                    if start is not None and end is not None:
+                        spans.append((int(start), int(end)))
+                    # The whole nested definition belongs to the nested symbol,
+                    # so there is no need to collect deeper spans here.
+                    continue
+                walk(child)
+
+        walk(node)
+        return spans
+
     def _visit_symbol(self, node: ast.AST, name: str) -> None:
         start = getattr(node, "lineno", None)
         end = getattr(node, "end_lineno", start)
-        if start is not None and end is not None and any(start <= line <= end for line in self.changed_lines):
+        changed_here = False
+        if start is not None and end is not None:
+            nested_spans = self._nested_symbol_spans(node)
+            for line in self.changed_lines:
+                if not (start <= line <= end):
+                    continue
+                if any(nested_start <= line <= nested_end for nested_start, nested_end in nested_spans):
+                    continue
+                changed_here = True
+                break
+        if changed_here:
             qualname = ".".join([*self.scope, name])
             self.symbols.append(
                 PythonSymbol(

--- a/tests/test_mock_relationships.py
+++ b/tests/test_mock_relationships.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pr_test_guard.check import analyze_repository
+
+
+def run(*args: str, cwd: Path) -> None:
+    subprocess.run(list(args), cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run("git", "init", "-b", "main", cwd=repo)
+    run("git", "config", "user.name", "Test User", cwd=repo)
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    return repo
+
+
+def commit_all(repo: Path, message: str) -> None:
+    run("git", "add", "-A", cwd=repo)
+    run("git", "commit", "-m", message, cwd=repo)
+
+
+def ptg005(result):
+    return [item for item in result.findings if item.rule_id == "PTG005"]
+
+
+def test_changed_test_mocking_changed_internal_callsite_is_reported(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "def calculate_retry(value):\n    return value + 1\n\n"
+        "def charge(value):\n    return value\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "def calculate_retry(value):\n    return value + 1\n\n"
+        "def charge(value):\n    return calculate_retry(value)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('service.calculate_retry')\n"
+        "def test_charge(mock_retry):\n    mock_retry.return_value = 3\n    assert charge_result(mock_retry) is not None\n\n"
+        "def charge_result(mock_retry):\n    return mock_retry.return_value\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "relation=direct_internal_dependency" in (findings[0].evidence or "")
+    assert "changed symbol=service.charge" in (findings[0].evidence or "")
+    assert "dependency target(s)=service.calculate_retry" in (findings[0].evidence or "")
+
+
+def test_patch_where_looked_up_matches_internal_imported_dependency(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "src/payment/__init__.py", "")
+    write(repo / "src/payment/retry.py", "def calculate_retry(value):\n    return value + 1\n")
+    write(
+        repo / "src/payment/service.py",
+        "from .retry import calculate_retry\n\n"
+        "def charge(value):\n    return value\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "src/payment/service.py",
+        "from .retry import calculate_retry\n\n"
+        "def charge(value):\n    return calculate_retry(value)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('payment.service.calculate_retry')\n"
+        "def test_charge(mock_retry):\n    assert mock_retry is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    evidence = findings[0].evidence or ""
+    assert "relation=direct_internal_dependency" in evidence
+    assert "payment.retry.calculate_retry" in evidence
+    assert "payment.service.calculate_retry" in evidence
+
+
+def test_external_import_mock_on_changed_callsite_is_suppressed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "import stripe\n\n"
+        "def charge(amount):\n    return None\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "import stripe\n\n"
+        "def charge(amount):\n    return stripe.PaymentIntent.create(amount=amount)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('service.stripe.PaymentIntent.create')\n"
+        "def test_charge(mock_create):\n    assert mock_create is not None\n",
+    )
+    commit_all(repo, "change")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    assert not ptg005(result)
+    external_notes = [note for note in result.notes if note.startswith("PTG005:")]
+    assert external_notes == ["PTG005: suppressed 1 external-boundary mock candidate(s) on changed call sites."]
+
+
+def test_external_definition_target_mock_is_also_suppressed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "import stripe\n\n"
+        "def charge(amount):\n    return None\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "import stripe\n\n"
+        "def charge(amount):\n    return stripe.PaymentIntent.create(amount=amount)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('stripe.PaymentIntent.create')\n"
+        "def test_charge(mock_create):\n    assert mock_create is not None\n",
+    )
+    commit_all(repo, "change")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    assert not ptg005(result)
+    external_notes = [note for note in result.notes if note.startswith("PTG005:")]
+    assert external_notes == ["PTG005: suppressed 1 external-boundary mock candidate(s) on changed call sites."]
+
+
+def test_unchanged_test_does_not_gain_indirect_dependency_warning(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "def calculate_retry(value):\n    return value + 1\n\n"
+        "def charge(value):\n    return calculate_retry(value)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('service.calculate_retry')\n"
+        "def test_charge(mock_retry):\n    assert mock_retry is not None\n",
+    )
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "def calculate_retry(value):\n    return value + 1\n\n"
+        "def charge(value):\n    return calculate_retry(value + 1)\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))
+
+
+def test_mock_of_unchanged_callsite_is_not_related_to_pr(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "def calculate_retry(value):\n    return value + 1\n\n"
+        "def charge(value):\n    value = calculate_retry(value)\n    return value\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "def calculate_retry(value):\n    return value + 1\n\n"
+        "def charge(value):\n    value = calculate_retry(value)\n    return value + 1\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('service.calculate_retry')\n"
+        "def test_charge(mock_retry):\n    assert mock_retry is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))
+
+
+def test_method_body_change_does_not_mark_class_container_as_changed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "class PaymentService:\n"
+        "    def charge(self):\n"
+        "        return False\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "class PaymentService:\n"
+        "    def charge(self):\n"
+        "        return True\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('service.PaymentService')\n"
+        "def test_charge(mock_service):\n    assert mock_service is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))
+
+
+def test_self_method_call_on_changed_line_is_internal_dependency(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "class PaymentService:\n"
+        "    def normalize(self, value):\n        return value\n\n"
+        "    def charge(self, value):\n        return value\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "class PaymentService:\n"
+        "    def normalize(self, value):\n        return value\n\n"
+        "    def charge(self, value):\n        return self.normalize(value)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\nfrom service import PaymentService\n\n"
+        "@patch.object(PaymentService, 'normalize')\n"
+        "def test_charge(mock_normalize):\n    assert mock_normalize is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "relation=direct_internal_dependency" in (findings[0].evidence or "")
+    assert "service.PaymentService.normalize" in (findings[0].evidence or "")
+
+
+def test_deep_self_attribute_chain_stays_unresolved(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "class PaymentService:\n"
+        "    def charge(self, value):\n        return value\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "class PaymentService:\n"
+        "    def charge(self, value):\n        return self.gateway.send(value)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\n\n"
+        "@patch('service.gateway.send')\n"
+        "def test_charge(mock_send):\n    assert mock_send is not None\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))


### PR DESCRIPTION
Extends PTG005 Semantic Lite with bounded changed-call relationship analysis. Direct mocks of changed symbols remain visible, while changed tests can now surface mocks of internal dependencies called on changed production lines. Explicit external SDK/API boundaries are recognized and suppressed, untouched tests and unchanged call sites remain conservative, and method-only changes no longer mark the containing class as changed. The implementation stays deterministic, offline, advisory, and dependency-free.