### PR TITLE
feat: add AST-scoped targeted probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">PR Test Guard</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.1.0-brightgreen.svg" alt="release v0.1.0" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/release-v0.2.0-brightgreen.svg" alt="release v0.2.0" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **Lightweight, rule-based test-quality checks for pull requests.**
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.1.0` adds direct real-PR analysis and ships the same analyzer as a reusable GitHub Action.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.0` adds AST-scoped targeted probe generation on top of the direct real-PR analyzer and reusable GitHub Action.
 
 | | |
 | --- | --- |
@@ -71,7 +71,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tigerless-labs/pr-test-guard@v0.1.0
+      - uses: tigerless-labs/pr-test-guard@v0.2.0
         with:
           base: origin/${{ github.base_ref }}
 ```
@@ -79,7 +79,7 @@ jobs:
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.1.0
+      - uses: tigerless-labs/pr-test-guard@v0.2.0
         with:
           base: origin/${{ github.base_ref }}
           coverage: coverage.xml
@@ -178,7 +178,7 @@ The reusable `action.yml` calls the same CLI/core. There is no separate hosted a
 
 The current mock detector uses a lightweight Python semantic layer before matching. It recognizes explicit patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, resolves common import aliases, preserves class/method qualified names, and normalizes common `src/` layouts. It then adds a bounded relationship pass: direct changed-symbol mocks remain visible, while mocks in tests changed by the PR can also be related to **direct internal dependencies whose call sites are themselves changed by the PR**. Explicit imported dependencies that resolve outside the repository are treated as external-boundary candidates and suppressed from PTG005 warnings. Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural relationship evidence does not prove that a mock is inappropriate.
 
-The targeted probe generator is deliberately limited. It covers a small set of status-code changes, boolean return flips, and comparison-boundary changes on lines added by the current PR. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
+The targeted probe generator is deliberately limited and AST-scoped. It covers a small set of status-code returns, boolean return flips, and comparison-boundary changes on lines added by the current PR while avoiding string/comment matches and unstable multi-line rewrites. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
 
 These deeper signals are part of the product's differentiation beyond patch coverage. Mock-boundary analysis stays static and advisory. Targeted probes are bounded, PR-scoped, and opt-in through `--deep` because they rerun repository tests. The goal is not a full mutation-testing campaign; it is a small number of review-focused probes against code changed by the current PR.
 
@@ -214,11 +214,11 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
-- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.1.0` prototype.
+- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.0` release.
 
 ## Current Scope
 
-Version `0.1.0` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Version `0.2.0` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -94,6 +94,6 @@ CI integration should be advisory by default. Repositories may later opt into st
 
 ## Current Limits
 
-Version `0.1.0` now provides a repository-native `check` command and a reusable GitHub Action for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
+Version `0.2.0` provides a repository-native `check` command, a reusable GitHub Action, and AST-scoped targeted probes for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -51,7 +51,7 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
   with:
     fetch-depth: 0
 
-- uses: tigerless-labs/pr-test-guard@v0.1.0
+- uses: tigerless-labs/pr-test-guard@v0.2.0
   with:
     base: origin/${{ github.base_ref }}
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,16 +2,16 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Version `0.1.0` is the first public-ready shape: direct real-PR checking, advisory GitHub Actions integration, static mock-boundary analysis, and optional bounded targeted probes.
+Version `0.2.0` keeps the first public-ready shape from `0.1.0` and adds AST-scoped targeted probe generation for the optional deep path.
 
-## What Exists in 0.1.0
+## What Exists in 0.2.0
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
 - optional `coverage.py` XML input for changed-line coverage signals;
 - obvious weak-assertion and test-weakening checks;
 - explicit Python mock-boundary candidates on changed symbols;
-- opt-in bounded targeted probes in an isolated Git worktree;
+- opt-in AST-scoped bounded targeted probes in an isolated Git worktree;
 - text, JSON, and GitHub Actions output;
 - reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
@@ -21,7 +21,7 @@ The fixture runner is development infrastructure for the tool. It is not the pro
 
 ## Current Main: PTG005 Semantic Lite
 
-The post-`0.1.0` PTG005 precision work remains deterministic and offline, but now has two bounded layers.
+The PTG005 precision work remains deterministic and offline, with two bounded layers.
 
 **Identity resolution**:
 

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -94,7 +94,7 @@ Human-readable report for the fixture. Findings are review signals and do not ce
 
 ## Stability
 
-Version `0.1.0` is still pre-release. Artifact fields may evolve as the rule logic is moved into the direct PR-facing CLI.
+Version `0.2.0` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
 
 Changes should preserve two properties:
 

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -22,22 +22,7 @@ from .mock_analysis import (
     extract_mock_targets,
     match_mock_target,
 )
-
-
-PROBE_REPLACEMENTS: tuple[tuple[str, str, str], ...] = (
-    ("return 400", "return 200", "weaken HTTP 400 return to success"),
-    ("return 401", "return 200", "weaken HTTP 401 return to success"),
-    ("return 403", "return 200", "weaken HTTP 403 return to success"),
-    ("return 404", "return 200", "weaken HTTP 404 return to success"),
-    ("return 409", "return 200", "weaken HTTP 409 return to success"),
-    ("return 422", "return 200", "weaken HTTP 422 return to success"),
-    ("return 500", "return 200", "weaken HTTP 500 return to success"),
-    ("return False", "return True", "flip false return"),
-    ("return True", "return False", "flip true return"),
-    (" <= ", " < ", "weaken inclusive upper-bound comparison"),
-    (" >= ", " > ", "weaken inclusive lower-bound comparison"),
-    (" == ", " != ", "flip equality comparison"),
-)
+from .probes import generate_probes
 
 
 class CheckError(RuntimeError):
@@ -567,33 +552,6 @@ def mock_boundary_findings(
         )
     return findings
 
-def generate_probes(
-    changed: dict[str, list[dict[str, Any]]],
-    max_probes: int,
-) -> list[dict[str, Any]]:
-    probes: list[dict[str, Any]] = []
-    for rel_path, lines in changed.items():
-        for item in lines:
-            content = item["content"]
-            for original, replacement, rationale in PROBE_REPLACEMENTS:
-                if original not in content:
-                    continue
-                probes.append(
-                    {
-                        "id": f"P{len(probes) + 1}",
-                        "file": rel_path,
-                        "line": item["line"],
-                        "original": original,
-                        "replacement": replacement,
-                        "rationale": rationale,
-                    }
-                )
-                break
-            if len(probes) >= max_probes:
-                return probes
-    return probes
-
-
 def run_shell(command: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, cwd=cwd, shell=True, capture_output=True, text=True)
 
@@ -614,7 +572,7 @@ def targeted_probe_findings(
     if not test_command:
         raise CheckError("--deep requires --test-command so PR Test Guard knows how to rerun the repository tests")
 
-    probes = generate_probes(changed, max_probes=max(1, max_probes))
+    probes = generate_probes(repo_root, changed, max_probes=max(1, max_probes))
     summary = {**empty_summary, "generated": len(probes)}
     if not probes:
         notes.append("PTG006: no supported targeted probe candidate was found in the changed Python lines.")
@@ -657,7 +615,11 @@ def targeted_probe_findings(
                             file=probe["file"],
                             line=probe["line"],
                             message="A bounded targeted probe survived the configured tests; the tests may be insensitive to this changed behavior.",
-                            evidence=f"{probe['original'].strip()} -> {probe['replacement'].strip()} ({probe['rationale']})",
+                            evidence=(
+                                f"kind={probe.get('kind', 'unknown')}; "
+                                f"{probe['original'].strip()} -> {probe['replacement'].strip()} "
+                                f"({probe['rationale']})"
+                            ),
                         )
                     )
         finally:

--- a/pr_test_guard/probes.py
+++ b/pr_test_guard/probes.py
@@ -1,0 +1,232 @@
+"""AST-scoped targeted probe generation for PTG006."""
+
+from __future__ import annotations
+
+import ast
+import io
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+STATUS_CODE_REPLACEMENTS: dict[int, tuple[int, str]] = {
+    400: (200, "weaken HTTP 400 return to success"),
+    401: (200, "weaken HTTP 401 return to success"),
+    403: (200, "weaken HTTP 403 return to success"),
+    404: (200, "weaken HTTP 404 return to success"),
+    409: (200, "weaken HTTP 409 return to success"),
+    422: (200, "weaken HTTP 422 return to success"),
+    500: (200, "weaken HTTP 500 return to success"),
+}
+
+COMPARE_OPERATOR_REPLACEMENTS: dict[type[ast.cmpop], tuple[str, str]] = {
+    ast.LtE: ("<", "weaken inclusive upper-bound comparison"),
+    ast.GtE: (">", "weaken inclusive lower-bound comparison"),
+    ast.Eq: ("!=", "flip equality comparison"),
+    ast.NotEq: ("==", "flip inequality comparison"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeCandidate:
+    id: str
+    file: str
+    line: int
+    original: str
+    replacement: str
+    rationale: str
+    kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "file": self.file,
+            "line": self.line,
+            "original": self.original,
+            "replacement": self.replacement,
+            "rationale": self.rationale,
+            "kind": self.kind,
+        }
+
+
+def _source_for_node(source: str, node: ast.AST) -> str:
+    return (ast.get_source_segment(source, node) or "").strip()
+
+
+def _node_span(node: ast.AST) -> tuple[int, int] | None:
+    start = getattr(node, "lineno", None)
+    end = getattr(node, "end_lineno", start)
+    if start is None or end is None:
+        return None
+    return int(start), int(end)
+
+
+def _intersects_changed_lines(node: ast.AST, changed_lines: set[int]) -> bool:
+    span = _node_span(node)
+    if span is None:
+        return False
+    start, end = span
+    return any(start <= line <= end for line in changed_lines)
+
+
+def _single_line(segment: str) -> bool:
+    return bool(segment) and "\n" not in segment and "\r" not in segment
+
+
+def _replace_single_line_segment(segment: str, old: str, new: str) -> str | None:
+    if not _single_line(segment) or old not in segment:
+        return None
+    return segment.replace(old, new, 1)
+
+
+def _replace_first_operator(segment: str, operator: str, replacement: str) -> str | None:
+    if not _single_line(segment):
+        return None
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(segment).readline))
+    except tokenize.TokenError:
+        return None
+    for token in tokens:
+        if token.type != tokenize.OP or token.string != operator:
+            continue
+        start_col = token.start[1]
+        end_col = token.end[1]
+        return f"{segment[:start_col]}{replacement}{segment[end_col:]}"
+    return None
+
+
+class _ProbeCollector(ast.NodeVisitor):
+    def __init__(self, source: str, rel_path: str, changed_lines: set[int]) -> None:
+        self.source = source
+        self.rel_path = rel_path
+        self.changed_lines = changed_lines
+        self.candidates: list[ProbeCandidate] = []
+
+    def _add(self, *, line: int, original: str, replacement: str, rationale: str, kind: str) -> None:
+        if original == replacement:
+            return
+        self.candidates.append(
+            ProbeCandidate(
+                id=f"P{len(self.candidates) + 1}",
+                file=self.rel_path,
+                line=line,
+                original=original,
+                replacement=replacement,
+                rationale=rationale,
+                kind=kind,
+            )
+        )
+
+    def visit_Return(self, node: ast.Return) -> None:  # noqa: N802
+        if not _intersects_changed_lines(node, self.changed_lines) or node.value is None:
+            return
+
+        original = _source_for_node(self.source, node)
+        if not _single_line(original):
+            return
+
+        value = node.value
+        value_source = _source_for_node(self.source, value)
+        if isinstance(value, ast.Constant) and isinstance(value.value, bool):
+            replacement_value = "False" if value.value is True else "True"
+            replacement = _replace_single_line_segment(original, value_source, replacement_value)
+            if replacement:
+                rationale = "flip true return" if value.value is True else "flip false return"
+                self._add(
+                    line=node.lineno,
+                    original=original,
+                    replacement=replacement,
+                    rationale=rationale,
+                    kind="boolean_return",
+                )
+            return
+
+        if isinstance(value, ast.Constant) and isinstance(value.value, int) and value.value in STATUS_CODE_REPLACEMENTS:
+            replacement_value, rationale = STATUS_CODE_REPLACEMENTS[value.value]
+            replacement = _replace_single_line_segment(original, value_source, str(replacement_value))
+            if replacement:
+                self._add(
+                    line=node.lineno,
+                    original=original,
+                    replacement=replacement,
+                    rationale=rationale,
+                    kind="return_status_code",
+                )
+            return
+
+        self.generic_visit(node)
+
+    def visit_Compare(self, node: ast.Compare) -> None:  # noqa: N802
+        if not _intersects_changed_lines(node, self.changed_lines):
+            return
+        original = _source_for_node(self.source, node)
+        if not _single_line(original):
+            return
+
+        for operator_node in node.ops:
+            operator_type = type(operator_node)
+            if operator_type not in COMPARE_OPERATOR_REPLACEMENTS:
+                continue
+            replacement_operator, rationale = COMPARE_OPERATOR_REPLACEMENTS[operator_type]
+            original_operator = _operator_text(operator_node)
+            replacement = _replace_first_operator(original, original_operator, replacement_operator)
+            if not replacement:
+                continue
+            self._add(
+                line=node.lineno,
+                original=original,
+                replacement=replacement,
+                rationale=rationale,
+                kind="comparison_boundary",
+            )
+            break
+
+        self.generic_visit(node)
+
+
+def _operator_text(operator: ast.cmpop) -> str:
+    if isinstance(operator, ast.LtE):
+        return "<="
+    if isinstance(operator, ast.GtE):
+        return ">="
+    if isinstance(operator, ast.Eq):
+        return "=="
+    if isinstance(operator, ast.NotEq):
+        return "!="
+    return ""
+
+
+def generate_probes(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+    *,
+    max_probes: int,
+) -> list[dict[str, Any]]:
+    probes: list[ProbeCandidate] = []
+    for rel_path, lines in changed.items():
+        path = repo_root / rel_path
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+
+        changed_lines = {int(item["line"]) for item in lines}
+        collector = _ProbeCollector(source, rel_path, changed_lines)
+        collector.visit(tree)
+        for candidate in collector.candidates:
+            probes.append(
+                ProbeCandidate(
+                    id=f"P{len(probes) + 1}",
+                    file=candidate.file,
+                    line=candidate.line,
+                    original=candidate.original,
+                    replacement=candidate.replacement,
+                    rationale=candidate.rationale,
+                    kind=candidate.kind,
+                )
+            )
+            if len(probes) >= max_probes:
+                return [item.to_dict() for item in probes]
+    return [item.to_dict() for item in probes]

--- a/pr_test_guard/version.py
+++ b/pr_test_guard/version.py
@@ -1,3 +1,3 @@
 """Project version."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-test-guard"
-version = "0.1.0"
+version = "0.2.0"
 description = "Lightweight, rule-based test-quality checks for pull requests."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 from pr_test_guard.check import analyze_repository
@@ -122,7 +123,7 @@ def test_targeted_probe_survivor_runs_in_isolated_worktree(tmp_path: Path) -> No
         repo,
         base="HEAD~1",
         deep=True,
-        test_command="python -m pytest -q",
+        test_command=f"{sys.executable} -m pytest -q",
         max_probes=1,
     )
     assert "PTG006" in rule_ids(result)

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pr_test_guard.probes import generate_probes
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_generates_return_status_probe_from_ast(tmp_path: Path) -> None:
+    write(tmp_path / "app.py", "def status(ok):\n    if not ok:\n        return 404\n    return 200\n")
+
+    probes = generate_probes(tmp_path, {"app.py": [{"line": 3, "content": "        return 404"}]}, max_probes=3)
+
+    assert probes == [
+        {
+            "id": "P1",
+            "file": "app.py",
+            "line": 3,
+            "original": "return 404",
+            "replacement": "return 200",
+            "rationale": "weaken HTTP 404 return to success",
+            "kind": "return_status_code",
+        }
+    ]
+
+
+def test_generates_comparison_probe_without_spacing_assumptions(tmp_path: Path) -> None:
+    write(tmp_path / "app.py", "def valid(amount):\n    return amount>=0\n")
+
+    probes = generate_probes(tmp_path, {"app.py": [{"line": 2, "content": "    return amount>=0"}]}, max_probes=3)
+
+    assert probes == [
+        {
+            "id": "P1",
+            "file": "app.py",
+            "line": 2,
+            "original": "amount>=0",
+            "replacement": "amount>0",
+            "rationale": "weaken inclusive lower-bound comparison",
+            "kind": "comparison_boundary",
+        }
+    ]
+
+
+def test_generates_boolean_return_probe(tmp_path: Path) -> None:
+    write(tmp_path / "app.py", "def enabled():\n    return True\n")
+
+    probes = generate_probes(tmp_path, {"app.py": [{"line": 2, "content": "    return True"}]}, max_probes=3)
+
+    assert probes[0]["original"] == "return True"
+    assert probes[0]["replacement"] == "return False"
+    assert probes[0]["kind"] == "boolean_return"
+
+
+def test_string_and_comment_text_do_not_generate_probes(tmp_path: Path) -> None:
+    write(
+        tmp_path / "app.py",
+        "def sample():\n"
+        "    text = 'return 404'\n"
+        "    # return 400\n"
+        "    return text\n",
+    )
+
+    probes = generate_probes(
+        tmp_path,
+        {
+            "app.py": [
+                {"line": 2, "content": "    text = 'return 404'"},
+                {"line": 3, "content": "    # return 400"},
+            ]
+        },
+        max_probes=3,
+    )
+
+    assert probes == []
+
+
+def test_unchanged_comparison_line_does_not_generate_probe(tmp_path: Path) -> None:
+    write(tmp_path / "app.py", "def valid(amount):\n    checked = amount >= 0\n    return checked\n")
+
+    probes = generate_probes(tmp_path, {"app.py": [{"line": 3, "content": "    return checked"}]}, max_probes=3)
+
+    assert probes == []
+
+
+def test_multiline_expression_is_skipped_when_replacement_is_not_stable(tmp_path: Path) -> None:
+    write(tmp_path / "app.py", "def valid(amount):\n    return (\n        amount >= 0\n    )\n")
+
+    probes = generate_probes(tmp_path, {"app.py": [{"line": 3, "content": "        amount >= 0"}]}, max_probes=3)
+
+    assert probes == []


### PR DESCRIPTION
## Summary
- add AST-scoped PTG006 probe generation for status-code returns, boolean returns, and comparison boundaries
- avoid string/comment matches and unstable multi-line rewrites
- bump package/docs to v0.2.0

## Tests
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run