### PR TITLE
chore: add sanitized dogfood review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Methodology](docs/methodology.md): the PR-centered evidence model and rule-design principles.
 - [Evaluation Design](docs/evaluation-design.md): how rules are validated without turning the project into a benchmark effort.
 - [Real PR Input](docs/real-pr-input.md): direct repository input, Action usage, optional coverage, and deep-probe boundaries.
+- [Dogfooding](docs/dogfooding.md): how to record shareable real-PR review summaries without committing raw PR details.
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -1,0 +1,69 @@
+# Dogfooding Review Workflow
+
+PR Test Guard should be validated on real pull requests, but this public
+repository should only contain shareable summaries. Keep repository-specific
+notes outside this repository and convert them into stable aliases before using
+them for public examples, aggregate counts, or rule-planning discussions.
+
+## Workflow
+
+1. Run `pr-test-guard check` on a real PR checkout.
+2. Review each finding as a reviewer would.
+3. Keep any raw notes in a local or private location.
+4. Convert the review into a sanitized record.
+5. Aggregate sanitized records to choose the next fixture or rule change.
+
+The sanitized record should preserve the evidence shape that matters for rule
+work while avoiding repository-specific details.
+
+## Reviewer Labels
+
+Use one label for each finding:
+
+- `useful`: the signal points to a concrete review concern.
+- `false_positive`: the signal is explainable but should not have warned.
+- `unclear`: the signal might matter, but the output lacks enough context.
+- `needs_more_context`: the rule needs another artifact, mapping, or policy input.
+
+## Shareable Fields
+
+Use aliases and coarse classifications:
+
+- `repo_alias`: stable value such as `repo_001`.
+- `pr_alias`: stable value such as `pr_001`.
+- `path_kind`: `production`, `test`, `docs`, `config`, or `unknown`.
+- `symbol_kind`: `function`, `method`, `class`, `module`, or `unknown`.
+- `dependency_kind`: `internal`, `external`, `unknown`, or `none`.
+- `evidence_shape`: a short reusable phrase such as
+  `changed test mocks dependency called from changed line`.
+
+Do not include repository URLs, PR URLs, branch names, real file paths, real
+symbols, dependency names, command strings, code snippets, CI logs, or raw
+finding evidence in records committed to this repository.
+
+## Local Layout
+
+A practical local layout is:
+
+```text
+~/private/pr-test-guard-dogfood/
+  raw/
+    repo-001-pr-001.json
+  sanitized/
+    repo-001-pr-001.json
+```
+
+The public repository can include sanitized examples under
+`examples/dogfood-reviews/` and scripts that operate on sanitized records. Raw
+notes should stay local or in a private workspace.
+
+## Aggregation
+
+Run:
+
+```bash
+python3 scripts/summarize_dogfood_reviews.py ~/private/pr-test-guard-dogfood/sanitized
+```
+
+Use the aggregate output to decide whether the next PR should add a regression
+fixture, tighten a rule, improve finding evidence, or only update documentation.

--- a/docs/validation-strategy.md
+++ b/docs/validation-strategy.md
@@ -52,6 +52,10 @@ needs more context
 
 This is enough to guide early releases. Formal precision/recall studies can be added later if the project develops a research need, but they are not required for the product roadmap.
 
+For public project materials, record shareable summaries rather than raw PR
+exports. Use stable aliases and coarse evidence shapes, and keep repository-
+specific notes outside this repository. See [Dogfooding](dogfooding.md).
+
 ## Layer 4: CI Behavior
 
 Validate that CI integration is safe and unsurprising:

--- a/examples/dogfood-reviews/README.md
+++ b/examples/dogfood-reviews/README.md
@@ -1,0 +1,11 @@
+# Dogfood Review Examples
+
+This directory contains shareable review-summary examples and the JSON schema
+for sanitized dogfooding records.
+
+Records committed here should use stable aliases and coarse classifications.
+Do not commit raw PR exports, repository URLs, real paths, real symbols, command
+strings, code snippets, CI logs, or raw finding evidence.
+
+Validate a record shape with any JSON Schema draft 2020-12 compatible validator,
+or use the repository tests for the built-in example and scripts.

--- a/examples/dogfood-reviews/sanitized-example.json
+++ b/examples/dogfood-reviews/sanitized-example.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "1",
+  "review_id": "sample_001",
+  "source": {
+    "visibility": "public_sample",
+    "repo_alias": "repo_001",
+    "pr_alias": "pr_001"
+  },
+  "environment": {
+    "language": "python",
+    "test_framework": "pytest",
+    "coverage_supplied": true,
+    "deep_enabled": true,
+    "test_command_shape": "pytest"
+  },
+  "findings": [
+    {
+      "rule_id": "PTG005",
+      "review_label": "false_positive",
+      "category": "legitimate_internal_helper_mock",
+      "path_kind": "test",
+      "symbol_kind": "function",
+      "dependency_kind": "internal",
+      "evidence_shape": "changed test mocks dependency called from changed line",
+      "action": "add_fixture"
+    },
+    {
+      "rule_id": "PTG006",
+      "review_label": "useful",
+      "category": "surviving_comparison_boundary_probe",
+      "path_kind": "production",
+      "symbol_kind": "function",
+      "dependency_kind": "none",
+      "evidence_shape": "comparison boundary probe survived configured tests",
+      "action": "no_change"
+    }
+  ]
+}

--- a/examples/dogfood-reviews/schema.json
+++ b/examples/dogfood-reviews/schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tigerless-labs/pr-test-guard/examples/dogfood-reviews/schema.json",
+  "title": "PR Test Guard sanitized dogfood review record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "review_id", "source", "environment", "findings"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "review_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["visibility", "repo_alias", "pr_alias"],
+      "properties": {
+        "visibility": {
+          "type": "string",
+          "enum": ["public_sample", "sanitized_private_review"]
+        },
+        "repo_alias": {
+          "type": "string",
+          "pattern": "^repo_[0-9]{3,}$"
+        },
+        "pr_alias": {
+          "type": "string",
+          "pattern": "^pr_[0-9]{3,}$"
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["language", "test_framework", "coverage_supplied", "deep_enabled"],
+      "properties": {
+        "language": {
+          "type": "string",
+          "enum": ["python", "unknown"]
+        },
+        "test_framework": {
+          "type": "string",
+          "enum": ["pytest", "unittest", "mixed", "unknown"]
+        },
+        "coverage_supplied": {
+          "type": "boolean"
+        },
+        "deep_enabled": {
+          "type": "boolean"
+        },
+        "test_command_shape": {
+          "type": "string",
+          "enum": ["pytest", "unittest", "custom", "none", "unknown"]
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "review_label", "category", "path_kind", "evidence_shape", "action"],
+        "properties": {
+          "rule_id": {
+            "type": "string",
+            "pattern": "^PTG[0-9]{3}$"
+          },
+          "review_label": {
+            "type": "string",
+            "enum": ["useful", "false_positive", "unclear", "needs_more_context"]
+          },
+          "category": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_:-]*$"
+          },
+          "path_kind": {
+            "type": "string",
+            "enum": ["production", "test", "docs", "config", "unknown"]
+          },
+          "symbol_kind": {
+            "type": "string",
+            "enum": ["function", "method", "class", "module", "unknown", "none"]
+          },
+          "dependency_kind": {
+            "type": "string",
+            "enum": ["internal", "external", "unknown", "none"]
+          },
+          "evidence_shape": {
+            "type": "string",
+            "minLength": 1
+          },
+          "action": {
+            "type": "string",
+            "enum": ["add_fixture", "tighten_rule", "improve_evidence", "docs_only", "no_change"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/sanitize_dogfood_review.py
+++ b/scripts/sanitize_dogfood_review.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Convert local dogfood notes into a shareable review summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VALID_LABELS = {"useful", "false_positive", "unclear", "needs_more_context"}
+VALID_ACTIONS = {"add_fixture", "tighten_rule", "improve_evidence", "docs_only", "no_change"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def _alias(value: Any, fallback: str, pattern: str) -> str:
+    if isinstance(value, str) and re.fullmatch(pattern, value):
+        return value
+    return fallback
+
+
+def _bool(value: Any) -> bool:
+    return bool(value) if isinstance(value, bool) else False
+
+
+def _test_command_shape(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "none"
+    lowered = value.lower()
+    if "pytest" in lowered:
+        return "pytest"
+    if "unittest" in lowered:
+        return "unittest"
+    return "custom"
+
+
+def _environment_command_shape(environment: dict[str, Any], raw: dict[str, Any]) -> str:
+    explicit = environment.get("test_command_shape")
+    if explicit in {"pytest", "unittest", "custom", "none", "unknown"}:
+        return explicit
+    return _test_command_shape(environment.get("test_command") or raw.get("test_command"))
+
+
+def _path_kind(value: Any) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    normalized = value.replace("\\", "/").lower()
+    name = normalized.rsplit("/", 1)[-1]
+    if "/tests/" in f"/{normalized}" or name.startswith("test_") or name.endswith("_test.py"):
+        return "test"
+    if normalized.endswith(".md") or normalized.startswith("docs/"):
+        return "docs"
+    if name in {"pyproject.toml", "setup.py", "tox.ini"} or normalized.startswith(".github/"):
+        return "config"
+    if normalized.endswith(".py"):
+        return "production"
+    return "unknown"
+
+
+def _safe_token(value: Any, fallback: str) -> str:
+    if not isinstance(value, str):
+        return fallback
+    token = value.strip().lower().replace("-", "_").replace(" ", "_")
+    token = re.sub(r"[^a-z0-9_:]+", "", token)
+    return token or fallback
+
+
+def _symbol_kind(value: Any) -> str:
+    token = _safe_token(value, "unknown")
+    return token if token in {"function", "method", "class", "module", "unknown", "none"} else "unknown"
+
+
+def _dependency_kind(value: Any) -> str:
+    token = _safe_token(value, "unknown")
+    return token if token in {"internal", "external", "unknown", "none"} else "unknown"
+
+
+def _review_label(value: Any) -> str:
+    token = _safe_token(value, "needs_more_context")
+    if token == "false_positive":
+        return token
+    return token if token in VALID_LABELS else "needs_more_context"
+
+
+def _action(value: Any) -> str:
+    token = _safe_token(value, "no_change")
+    return token if token in VALID_ACTIONS else "no_change"
+
+
+def _evidence_shape(finding: dict[str, Any]) -> str:
+    explicit = finding.get("evidence_shape")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    rule_id = finding.get("rule_id")
+    if rule_id == "PTG005":
+        return "mock boundary relationship signal"
+    if rule_id == "PTG006":
+        return "targeted probe survivor signal"
+    return "rule finding signal"
+
+
+def sanitize_review(raw: dict[str, Any]) -> dict[str, Any]:
+    source = raw.get("source") if isinstance(raw.get("source"), dict) else {}
+    environment = raw.get("environment") if isinstance(raw.get("environment"), dict) else {}
+    raw_findings = raw.get("findings") if isinstance(raw.get("findings"), list) else []
+
+    sanitized_findings: list[dict[str, Any]] = []
+    for item in raw_findings:
+        if not isinstance(item, dict):
+            continue
+        rule_id = item.get("rule_id")
+        if not isinstance(rule_id, str) or not re.fullmatch(r"PTG[0-9]{3}", rule_id):
+            continue
+        sanitized_findings.append(
+            {
+                "rule_id": rule_id,
+                "review_label": _review_label(item.get("review_label") or item.get("label")),
+                "category": _safe_token(item.get("category"), "uncategorized"),
+                "path_kind": item.get("path_kind") if item.get("path_kind") in {"production", "test", "docs", "config", "unknown"} else _path_kind(item.get("file") or item.get("path")),
+                "symbol_kind": _symbol_kind(item.get("symbol_kind")),
+                "dependency_kind": _dependency_kind(item.get("dependency_kind")),
+                "evidence_shape": _evidence_shape(item),
+                "action": _action(item.get("action")),
+            }
+        )
+
+    return {
+        "schema_version": "1",
+        "review_id": _alias(raw.get("review_id"), "review_001", r"[a-z0-9][a-z0-9_-]*"),
+        "source": {
+            "visibility": "sanitized_private_review",
+            "repo_alias": _alias(source.get("repo_alias") or raw.get("repo_alias"), "repo_001", r"repo_[0-9]{3,}"),
+            "pr_alias": _alias(source.get("pr_alias") or raw.get("pr_alias"), "pr_001", r"pr_[0-9]{3,}"),
+        },
+        "environment": {
+            "language": "python" if environment.get("language") == "python" else "unknown",
+            "test_framework": environment.get("test_framework") if environment.get("test_framework") in {"pytest", "unittest", "mixed", "unknown"} else "unknown",
+            "coverage_supplied": _bool(environment.get("coverage_supplied")),
+            "deep_enabled": _bool(environment.get("deep_enabled")),
+            "test_command_shape": _environment_command_shape(environment, raw),
+        },
+        "findings": sanitized_findings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", type=Path, help="local dogfood review JSON")
+    parser.add_argument("-o", "--output", type=Path, help="path for sanitized JSON; stdout when omitted")
+    args = parser.parse_args()
+
+    try:
+        sanitized = sanitize_review(load_json(args.input))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        write_json(args.output, sanitized)
+    else:
+        print(json.dumps(sanitized, indent=2, sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/summarize_dogfood_reviews.py
+++ b/scripts/summarize_dogfood_reviews.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Summarize sanitized dogfood review records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+LABELS = ("useful", "false_positive", "unclear", "needs_more_context")
+
+
+def load_records(root: Path) -> list[dict[str, Any]]:
+    if root.is_file():
+        paths = [root]
+    else:
+        paths = sorted(root.glob("*.json"))
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"{path}: expected a JSON object")
+        if value.get("schema_version") != "1" or not isinstance(value.get("findings"), list):
+            continue
+        records.append(value)
+    return records
+
+
+def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    by_rule: dict[str, dict[str, Any]] = {}
+    category_counts: dict[str, Counter[str]] = defaultdict(Counter)
+
+    for record in records:
+        findings = record.get("findings")
+        if not isinstance(findings, list):
+            continue
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            rule_id = finding.get("rule_id")
+            label = finding.get("review_label")
+            category = finding.get("category")
+            if not isinstance(rule_id, str) or label not in LABELS:
+                continue
+            bucket = by_rule.setdefault(
+                rule_id,
+                {
+                    "total": 0,
+                    "labels": {item: 0 for item in LABELS},
+                    "top_categories": [],
+                    "recommended_next_actions": [],
+                },
+            )
+            bucket["total"] += 1
+            bucket["labels"][label] += 1
+            if isinstance(category, str) and category:
+                category_counts[rule_id][category] += 1
+
+    for rule_id, bucket in by_rule.items():
+        bucket["top_categories"] = [
+            {"category": category, "count": count}
+            for category, count in category_counts[rule_id].most_common(5)
+        ]
+        bucket["recommended_next_actions"] = _recommended_actions(bucket)
+
+    return {
+        "record_count": len(records),
+        "finding_count": sum(item["total"] for item in by_rule.values()),
+        "rules": dict(sorted(by_rule.items())),
+    }
+
+
+def _recommended_actions(bucket: dict[str, Any]) -> list[str]:
+    labels = bucket["labels"]
+    actions: list[str] = []
+    if labels["false_positive"]:
+        actions.append("add_negative_control_fixture")
+        actions.append("tighten_rule_or_evidence")
+    if labels["unclear"] or labels["needs_more_context"]:
+        actions.append("improve_finding_context")
+    if labels["useful"] and not actions:
+        actions.append("keep_rule_behavior")
+    return actions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path, help="sanitized record file or directory")
+    args = parser.parse_args()
+
+    try:
+        summary = summarize_records(load_records(args.path))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, indent=2, sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dogfood_workflow.py
+++ b/tests/test_dogfood_workflow.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str):
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+sanitize_module = load_script("sanitize_dogfood_review.py")
+summary_module = load_script("summarize_dogfood_reviews.py")
+
+
+def test_sanitize_review_drops_repository_specific_details() -> None:
+    raw = {
+        "review_id": "real_review_001",
+        "repo_url": "https://github.com/example/private-repo",
+        "pr_url": "https://github.com/example/private-repo/pull/123",
+        "repo_alias": "repo_123",
+        "pr_alias": "pr_456",
+        "test_command": "pytest tests/private_payment_flow.py -q",
+        "environment": {
+            "language": "python",
+            "test_framework": "pytest",
+            "coverage_supplied": True,
+            "deep_enabled": True,
+        },
+        "findings": [
+            {
+                "rule_id": "PTG005",
+                "label": "false_positive",
+                "category": "Legitimate Internal Helper Mock",
+                "file": "tests/payments/test_private_gateway.py",
+                "symbol": "PrivatePaymentService.charge",
+                "dependency": "private_gateway.client.create",
+                "evidence": "changed symbol=private.payment.PrivatePaymentService.charge",
+                "evidence_shape": "changed test mocks dependency called from changed line",
+                "action": "add_fixture",
+            }
+        ],
+    }
+
+    sanitized = sanitize_module.sanitize_review(raw)
+    rendered = json.dumps(sanitized)
+
+    assert sanitized["source"] == {
+        "visibility": "sanitized_private_review",
+        "repo_alias": "repo_123",
+        "pr_alias": "pr_456",
+    }
+    assert sanitized["environment"]["test_command_shape"] == "pytest"
+    assert sanitized["findings"][0]["path_kind"] == "test"
+    assert sanitized["findings"][0]["category"] == "legitimate_internal_helper_mock"
+    assert "private-repo" not in rendered
+    assert "test_private_gateway.py" not in rendered
+    assert "PrivatePaymentService" not in rendered
+    assert "private_gateway" not in rendered
+    assert "pytest tests/private_payment_flow.py -q" not in rendered
+
+
+def test_summarize_records_counts_labels_and_categories() -> None:
+    records = [
+        {
+            "schema_version": "1",
+            "review_id": "review_001",
+            "source": {"visibility": "sanitized_private_review", "repo_alias": "repo_001", "pr_alias": "pr_001"},
+            "environment": {"language": "python", "test_framework": "pytest", "coverage_supplied": True, "deep_enabled": False},
+            "findings": [
+                {
+                    "rule_id": "PTG005",
+                    "review_label": "false_positive",
+                    "category": "legitimate_internal_helper_mock",
+                    "path_kind": "test",
+                    "evidence_shape": "changed test mocks dependency called from changed line",
+                    "action": "add_fixture",
+                },
+                {
+                    "rule_id": "PTG006",
+                    "review_label": "useful",
+                    "category": "surviving_comparison_boundary_probe",
+                    "path_kind": "production",
+                    "evidence_shape": "comparison boundary probe survived configured tests",
+                    "action": "no_change",
+                },
+            ],
+        },
+        {
+            "schema_version": "1",
+            "review_id": "review_002",
+            "source": {"visibility": "sanitized_private_review", "repo_alias": "repo_002", "pr_alias": "pr_001"},
+            "environment": {"language": "python", "test_framework": "pytest", "coverage_supplied": False, "deep_enabled": True},
+            "findings": [
+                {
+                    "rule_id": "PTG005",
+                    "review_label": "unclear",
+                    "category": "legitimate_internal_helper_mock",
+                    "path_kind": "test",
+                    "evidence_shape": "changed test mocks dependency called from changed line",
+                    "action": "improve_evidence",
+                }
+            ],
+        },
+    ]
+
+    summary = summary_module.summarize_records(records)
+
+    assert summary["record_count"] == 2
+    assert summary["finding_count"] == 3
+    assert summary["rules"]["PTG005"]["labels"]["false_positive"] == 1
+    assert summary["rules"]["PTG005"]["labels"]["unclear"] == 1
+    assert summary["rules"]["PTG005"]["top_categories"] == [
+        {"category": "legitimate_internal_helper_mock", "count": 2}
+    ]
+    assert "add_negative_control_fixture" in summary["rules"]["PTG005"]["recommended_next_actions"]
+    assert summary["rules"]["PTG006"]["recommended_next_actions"] == ["keep_rule_behavior"]
+
+
+def test_load_records_skips_schema_documents() -> None:
+    records = summary_module.load_records(ROOT / "examples" / "dogfood-reviews")
+
+    assert [record["review_id"] for record in records] == ["sample_001"]
+
+
+def test_sanitize_preserves_existing_command_shape() -> None:
+    raw = {
+        "review_id": "review_001",
+        "environment": {"test_command_shape": "pytest"},
+        "findings": [],
+    }
+
+    sanitized = sanitize_module.sanitize_review(raw)
+
+    assert sanitized["environment"]["test_command_shape"] == "pytest"


### PR DESCRIPTION
## Summary
- document a public-safe dogfooding workflow for real PR review summaries
- add a sanitized review schema and sample record
- add sanitizer and summary scripts for dogfood review records
- cover sanitizer and summarizer behavior with tests

## Tests
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run