### PR TITLE
fix: suppress constrained PTG005 dependency mocks

### DIFF
--- a/cases/python/legitimate_helper_mock_001/claim.json
+++ b/cases/python/legitimate_helper_mock_001/claim.json
@@ -1,0 +1,11 @@
+{
+  "claims": [
+    {
+      "id": "C1",
+      "text": "Processing a payload adds source='api' before sending it.",
+      "trigger": "payload is processed",
+      "expected_outcome": "sender receives enriched payload",
+      "source": "issue.md"
+    }
+  ]
+}

--- a/cases/python/legitimate_helper_mock_001/expected_findings.json
+++ b/cases/python/legitimate_helper_mock_001/expected_findings.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "legitimate_helper_mock_001",
+  "claims": [
+    {
+      "claim_id": "C1",
+      "adequacy": "supported",
+      "findings": [
+        {
+          "type": "Evidence Complete",
+          "evidence_refs": [
+            "repo/tests/test_service.py::test_process_payload_sends_enriched_payload"
+          ],
+          "rationale": "The test mocks the sender boundary but constrains the changed process_payload contract with assert_called_once_with."
+        }
+      ]
+    }
+  ]
+}

--- a/cases/python/legitimate_helper_mock_001/issue.md
+++ b/cases/python/legitimate_helper_mock_001/issue.md
@@ -1,0 +1,7 @@
+# Issue
+
+`process_payload` should enrich every outgoing payload with the API source before
+handing it to the sender helper.
+
+The sender helper itself can stay mocked in the unit test; the behavior under
+review is the interaction contract created by `process_payload`.

--- a/cases/python/legitimate_helper_mock_001/metadata.json
+++ b/cases/python/legitimate_helper_mock_001/metadata.json
@@ -1,0 +1,8 @@
+{
+  "language": "python",
+  "test_framework": "pytest",
+  "fixture_kind": "executable_micro_pr",
+  "case_id": "legitimate_helper_mock_001",
+  "case_family": "PTG005 Negative Control",
+  "expected_output_source": "controlled_construction"
+}

--- a/cases/python/legitimate_helper_mock_001/pr.patch
+++ b/cases/python/legitimate_helper_mock_001/pr.patch
@@ -1,0 +1,30 @@
+diff --git a/service.py b/service.py
+--- a/service.py
++++ b/service.py
+@@ -3,4 +3,5 @@
+ 
+ 
+ def process_payload(payload: dict[str, str]) -> bool:
+-    return send_payload(payload)
++    enriched = {**payload, "source": "api"}
++    return send_payload(enriched)
+diff --git a/tests/test_service.py b/tests/test_service.py
+--- a/tests/test_service.py
++++ b/tests/test_service.py
+@@ -1,7 +1,16 @@
++from unittest.mock import patch
++
+ from service import process_payload
+ 
+ 
+ def test_process_payload_sends_original_payload():
+     payload = {"id": "42"}
+ 
+     assert process_payload(payload) is True
++
++
++@patch("service.send_payload")
++def test_process_payload_sends_enriched_payload(mock_send):
++    mock_send.return_value = True
++    assert process_payload({"id": "42"}) is True
++    mock_send.assert_called_once_with({"id": "42", "source": "api"})

--- a/cases/python/legitimate_helper_mock_001/repo/service.py
+++ b/cases/python/legitimate_helper_mock_001/repo/service.py
@@ -1,0 +1,6 @@
+def send_payload(payload: dict[str, str]) -> bool:
+    return True
+
+
+def process_payload(payload: dict[str, str]) -> bool:
+    return send_payload(payload)

--- a/cases/python/legitimate_helper_mock_001/repo/tests/test_service.py
+++ b/cases/python/legitimate_helper_mock_001/repo/tests/test_service.py
@@ -1,0 +1,7 @@
+from service import process_payload
+
+
+def test_process_payload_sends_original_payload():
+    payload = {"id": "42"}
+
+    assert process_payload(payload) is True

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -67,3 +67,11 @@ python3 scripts/summarize_dogfood_reviews.py ~/private/pr-test-guard-dogfood/san
 
 Use the aggregate output to decide whether the next PR should add a regression
 fixture, tighten a rule, improve finding evidence, or only update documentation.
+
+## From Summary to Fixture
+
+When the same sanitized category appears repeatedly as a `false_positive` or
+`unclear` signal, add the smallest public-safe fixture that captures the rule
+boundary. The fixture should use fictional code and stable names, and its
+expected output should define the intended behavior without copying details from
+the original PR.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -55,9 +55,9 @@ The current Python prototype extracts assertion structure and can flag obvious w
 
 ### Mock-boundary evidence
 
-Mocks are neutral. The current structural detector only raises a candidate when an explicit patch target overlaps changed code that appears central to the tested path.
+Mocks are neutral. The current structural detector raises a candidate when an explicit patch target overlaps changed code that appears central to the tested path, or when a changed test mocks an internal dependency called on a changed production line without a clear interaction or owner-outcome assertion.
 
-A mock candidate should tell a reviewer where to look; it should not automatically fail a PR.
+A mock candidate should tell a reviewer where to look; it should not automatically fail a PR. A dependency mock that constrains the changed owner's interaction contract, return value, or exception behavior is treated differently from a mock that simply replaces behavior and then makes a weak existence assertion.
 
 ### Counterfactual evidence
 

--- a/docs/rule-fixtures.md
+++ b/docs/rule-fixtures.md
@@ -31,6 +31,7 @@ The `claim.json` shape is retained from the original prototype because current r
 - `weak_assertion_001`: exercises an obviously weak assertion pattern.
 - `issue_test_mismatch_001`: exercises a test that covers a different behavior path.
 - `mocked_core_path_001`: exercises an explicit mock that replaces changed behavior.
+- `legitimate_helper_mock_001`: negative control for a dependency mock with an interaction-contract assertion.
 - `evidence_complete_001`: positive control where the targeted behavior is directly asserted.
 
 ## Positive and Negative Controls

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -19,6 +19,7 @@ from .mock_analysis import (
     classify_dependency_relation,
     collect_changed_dependency_calls,
     collect_changed_symbols,
+    dependency_mock_is_constrained,
     extract_mock_targets,
     match_mock_target,
 )
@@ -458,10 +459,16 @@ def mock_boundary_findings(
         tracked_python_paths=production_python_files,
     )
     changed_test_files = {item.path for item in files if is_test_path(item.path) and item.status != "D"}
+    changed_test_lines = {
+        item.path: {line for line, _ in item.added}
+        for item in files
+        if is_test_path(item.path) and item.status != "D"
+    }
 
     findings: list[Finding] = []
     seen: set[tuple[str, int, str]] = set()
     suppressed_external = 0
+    suppressed_constrained = 0
 
     for rel_path in (line for line in python_files if is_test_path(line)):
         path = repo_root / rel_path
@@ -523,6 +530,16 @@ def mock_boundary_findings(
             owner = relationship.changed_symbol
             if dependency is None or owner is None:
                 continue
+            constraint = dependency_mock_is_constrained(
+                tree,
+                target=target,
+                owner=owner,
+                added_lines=changed_test_lines.get(rel_path, set()),
+            )
+            if constraint.constrained:
+                suppressed_constrained += 1
+                seen.add(key)
+                continue
             seen.add(key)
             resolved = target.resolved_target or "unresolved"
             dependency_targets = ", ".join(dependency.candidate_targets)
@@ -549,6 +566,11 @@ def mock_boundary_findings(
         notes.append(
             "PTG005: suppressed "
             f"{suppressed_external} external-boundary mock candidate(s) on changed call sites."
+        )
+    if suppressed_constrained:
+        notes.append(
+            "PTG005: suppressed "
+            f"{suppressed_constrained} constrained dependency mock candidate(s) with interaction or owner-outcome assertions."
         )
     return findings
 

--- a/pr_test_guard/mock_analysis/__init__.py
+++ b/pr_test_guard/mock_analysis/__init__.py
@@ -11,8 +11,10 @@ from .relations import (
     collect_changed_dependency_calls,
 )
 from .symbols import PythonSymbol, collect_changed_symbols, module_name_from_path
+from .test_semantics import BoundaryConstraint, dependency_mock_is_constrained
 
 __all__ = [
+    "BoundaryConstraint",
     "DependencyCall",
     "MatchKind",
     "MockMatch",
@@ -25,6 +27,7 @@ __all__ = [
     "classify_dependency_relation",
     "collect_changed_dependency_calls",
     "collect_changed_symbols",
+    "dependency_mock_is_constrained",
     "extract_mock_targets",
     "match_mock_target",
     "module_name_from_path",

--- a/pr_test_guard/mock_analysis/test_semantics.py
+++ b/pr_test_guard/mock_analysis/test_semantics.py
@@ -1,0 +1,224 @@
+"""Bounded test-semantics helpers for PTG005 dependency mocks."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+from .mocks import MockTarget, dotted_name
+from .symbols import PythonSymbol
+
+
+INTERACTION_ASSERTIONS = {
+    "assert_any_call",
+    "assert_called",
+    "assert_called_once",
+    "assert_called_once_with",
+    "assert_called_with",
+    "assert_has_calls",
+    "assert_not_called",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryConstraint:
+    constrained: bool
+    reason: str
+
+
+def dependency_mock_is_constrained(
+    tree: ast.AST,
+    *,
+    target: MockTarget,
+    owner: PythonSymbol,
+    added_lines: set[int],
+) -> BoundaryConstraint:
+    """Detect whether a dependency mock is used as a constrained boundary.
+
+    This is intentionally narrower than business-intent understanding.  It
+    looks for deterministic test evidence that the changed owner behavior is
+    still constrained through either interaction assertions on the mock or a
+    non-weak assertion over the owner call result.
+    """
+
+    test_node = _enclosing_test_function(tree, target.line)
+    if test_node is None:
+        return BoundaryConstraint(False, "no_enclosing_test_function")
+
+    mock_names = _mock_names_for_target(test_node, target)
+    if mock_names and _has_added_interaction_assertion(test_node, mock_names, added_lines):
+        return BoundaryConstraint(True, "interaction_assertion")
+
+    owner_result_names = _owner_result_names(test_node, owner)
+    if _has_added_owner_outcome_assertion(test_node, owner, owner_result_names, added_lines):
+        return BoundaryConstraint(True, "owner_outcome_assertion")
+
+    if _has_added_pytest_raises_for_owner(test_node, owner, added_lines):
+        return BoundaryConstraint(True, "owner_exception_assertion")
+
+    return BoundaryConstraint(False, "no_interaction_or_outcome_constraint")
+
+
+def _enclosing_test_function(tree: ast.AST, line: int) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    matches: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        start = getattr(node, "lineno", None)
+        end = getattr(node, "end_lineno", start)
+        if start is not None and end is not None and int(start) <= line <= int(end):
+            matches.append(node)
+            continue
+        for decorator in node.decorator_list:
+            deco_start = getattr(decorator, "lineno", None)
+            deco_end = getattr(decorator, "end_lineno", deco_start)
+            if deco_start is not None and deco_end is not None and int(deco_start) <= line <= int(deco_end):
+                matches.append(node)
+                break
+    if not matches:
+        return None
+    return max(matches, key=lambda item: int(getattr(item, "lineno", 0)))
+
+
+def _mock_names_for_target(test_node: ast.FunctionDef | ast.AsyncFunctionDef, target: MockTarget) -> set[str]:
+    names: set[str] = set()
+    target_leaf = target.raw_target.strip().strip("'\"").rsplit(".", 1)[-1].lower()
+
+    for arg in [*test_node.args.posonlyargs, *test_node.args.args, *test_node.args.kwonlyargs]:
+        if arg.arg.startswith("mock") or target_leaf in arg.arg.lower():
+            names.add(arg.arg)
+
+    for node in ast.walk(test_node):
+        if isinstance(node, ast.With):
+            for item in node.items:
+                line = getattr(item.context_expr, "lineno", None)
+                if line == target.line and isinstance(item.optional_vars, ast.Name):
+                    names.add(item.optional_vars.id)
+        elif isinstance(node, ast.Assign):
+            line = getattr(node.value, "lineno", None)
+            if line == target.line:
+                names.update(_assigned_names(node.targets))
+        elif isinstance(node, ast.AnnAssign):
+            line = getattr(node.value, "lineno", None) if node.value is not None else None
+            if line == target.line:
+                names.update(_assigned_names([node.target]))
+
+    return names
+
+
+def _assigned_names(targets: list[ast.expr]) -> set[str]:
+    names: set[str] = set()
+    for target in targets:
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            names.update(_assigned_names([item for item in target.elts if isinstance(item, ast.expr)]))
+    return names
+
+
+def _root_name(name: str) -> str:
+    return name.split(".", 1)[0]
+
+
+def _is_added(node: ast.AST, added_lines: set[int]) -> bool:
+    line = getattr(node, "lineno", None)
+    return line in added_lines if line is not None else False
+
+
+def _has_added_interaction_assertion(
+    test_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    mock_names: set[str],
+    added_lines: set[int],
+) -> bool:
+    for node in ast.walk(test_node):
+        if isinstance(node, ast.Call) and _is_added(node, added_lines):
+            name = dotted_name(node.func)
+            if not name:
+                continue
+            parts = name.split(".")
+            if parts[-1] in INTERACTION_ASSERTIONS and _root_name(name) in mock_names:
+                return True
+        if isinstance(node, ast.Assert) and _is_added(node, added_lines):
+            for child in ast.walk(node.test):
+                if isinstance(child, ast.Attribute):
+                    name = dotted_name(child)
+                    if not name:
+                        continue
+                    if _root_name(name) in mock_names and name.split(".")[-1] in {"call_args", "call_count"}:
+                        return True
+    return False
+
+
+def _owner_result_names(test_node: ast.FunctionDef | ast.AsyncFunctionDef, owner: PythonSymbol) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(test_node):
+        if isinstance(node, ast.Assign) and _contains_owner_call(node.value, owner):
+            names.update(_assigned_names(node.targets))
+        elif isinstance(node, ast.AnnAssign) and node.value is not None and _contains_owner_call(node.value, owner):
+            names.update(_assigned_names([node.target]))
+    return names
+
+
+def _has_added_owner_outcome_assertion(
+    test_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    owner: PythonSymbol,
+    owner_result_names: set[str],
+    added_lines: set[int],
+) -> bool:
+    for node in ast.walk(test_node):
+        if not isinstance(node, ast.Assert) or not _is_added(node, added_lines):
+            continue
+        if not _is_strong_assertion(node.test):
+            continue
+        if _contains_owner_call(node.test, owner) or _contains_owner_result_name(node.test, owner_result_names):
+            return True
+    return False
+
+
+def _has_added_pytest_raises_for_owner(
+    test_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    owner: PythonSymbol,
+    added_lines: set[int],
+) -> bool:
+    for node in ast.walk(test_node):
+        if not isinstance(node, ast.With) or not _is_added(node, added_lines):
+            continue
+        has_raises = any(dotted_name(item.context_expr.func) == "pytest.raises" for item in node.items if isinstance(item.context_expr, ast.Call))
+        if has_raises and any(isinstance(child, ast.Call) and _is_owner_call(child, owner) for child in ast.walk(node)):
+            return True
+    return False
+
+
+def _contains_owner_call(node: ast.AST, owner: PythonSymbol) -> bool:
+    return any(isinstance(child, ast.Call) and _is_owner_call(child, owner) for child in ast.walk(node))
+
+
+def _is_owner_call(node: ast.Call, owner: PythonSymbol) -> bool:
+    name = dotted_name(node.func)
+    if not name:
+        return False
+    owner_leaf = owner.name
+    owner_qualname = owner.qualname
+    return name == owner_leaf or name.endswith(f".{owner_leaf}") or name.endswith(f".{owner_qualname}")
+
+
+def _contains_owner_result_name(node: ast.AST, owner_result_names: set[str]) -> bool:
+    return bool(owner_result_names) and any(
+        isinstance(child, ast.Name) and child.id in owner_result_names for child in ast.walk(node)
+    )
+
+
+def _is_strong_assertion(test: ast.AST) -> bool:
+    if isinstance(test, ast.Compare):
+        if any(isinstance(comparator, ast.Constant) and comparator.value is None for comparator in test.comparators):
+            return False
+        if any(isinstance(op, (ast.Is, ast.IsNot)) for op in test.ops):
+            return False
+        return True
+    if isinstance(test, ast.Call):
+        return False
+    if isinstance(test, (ast.Name, ast.Attribute)):
+        return False
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        return False
+    return False

--- a/tests/test_mock_relationships.py
+++ b/tests/test_mock_relationships.py
@@ -64,6 +64,123 @@ def test_changed_test_mocking_changed_internal_callsite_is_reported(tmp_path: Pa
     assert "dependency target(s)=service.calculate_retry" in (findings[0].evidence or "")
 
 
+def test_internal_dependency_mock_with_interaction_assertion_is_suppressed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "def send_payload(payload):\n    return True\n\n"
+        "def process(payload):\n    return send_payload(payload)\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "def send_payload(payload):\n    return True\n\n"
+        "def process(payload):\n    enriched = {**payload, 'source': 'api'}\n    return send_payload(enriched)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\nfrom service import process\n\n"
+        "@patch('service.send_payload')\n"
+        "def test_process(mock_send):\n"
+        "    mock_send.return_value = True\n"
+        "    assert process({'id': '42'}) is True\n"
+        "    mock_send.assert_called_once_with({'id': '42', 'source': 'api'})\n",
+    )
+    commit_all(repo, "change")
+
+    result = analyze_repository(repo, base="HEAD~1")
+    assert not ptg005(result)
+    notes = [note for note in result.notes if note.startswith("PTG005: suppressed")]
+    assert notes == [
+        "PTG005: suppressed 1 constrained dependency mock candidate(s) with interaction or owner-outcome assertions."
+    ]
+
+
+def test_internal_dependency_mock_with_owner_outcome_assertion_is_suppressed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "def calculate_tax(amount):\n    return amount\n\n"
+        "def total(amount):\n    return calculate_tax(amount)\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "def calculate_tax(amount):\n    return amount\n\n"
+        "def total(amount):\n    return {'total': amount + calculate_tax(amount)}\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\nfrom service import total\n\n"
+        "@patch('service.calculate_tax')\n"
+        "def test_total(mock_tax):\n"
+        "    mock_tax.return_value = 2\n"
+        "    result = total(10)\n"
+        "    assert result == {'total': 12}\n",
+    )
+    commit_all(repo, "change")
+
+    assert not ptg005(analyze_repository(repo, base="HEAD~1"))
+
+
+def test_internal_dependency_mock_with_only_weak_assertion_is_still_reported(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "service.py",
+        "def send_payload(payload):\n    return True\n\n"
+        "def process(payload):\n    return True\n",
+    )
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "service.py",
+        "def send_payload(payload):\n    return True\n\n"
+        "def process(payload):\n    return send_payload(payload)\n",
+    )
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\nfrom service import process\n\n"
+        "@patch('service.send_payload')\n"
+        "def test_process(mock_send):\n"
+        "    mock_send.return_value = True\n"
+        "    result = process({'id': '42'})\n"
+        "    assert result is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "relation=direct_internal_dependency" in (findings[0].evidence or "")
+
+
+def test_direct_changed_symbol_mock_is_reported_even_with_interaction_assertion(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "service.py", "def charge(amount):\n    return amount > 0\n")
+    write(repo / "tests/test_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(repo / "service.py", "def charge(amount):\n    return amount >= 0\n")
+    write(
+        repo / "tests/test_service.py",
+        "from unittest.mock import patch\nfrom service import charge\n\n"
+        "@patch('service.charge')\n"
+        "def test_charge(mock_charge):\n"
+        "    mock_charge.return_value = True\n"
+        "    assert charge(0) is True\n"
+        "    mock_charge.assert_called_once_with(0)\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+    assert len(findings) == 1
+    assert "relation=direct_changed_symbol" in (findings[0].evidence or "")
+
+
 def test_patch_where_looked_up_matches_internal_imported_dependency(tmp_path: Path) -> None:
     repo = make_repo(tmp_path)
     write(repo / "src/payment/__init__.py", "")


### PR DESCRIPTION
## Summary
- add deterministic test-semantics checks for PTG005 dependency mocks
- suppress internal dependency mock candidates when changed tests constrain interaction or owner outcome behavior
- keep direct changed-symbol mock warnings unchanged
- add a legitimate helper-mock negative-control fixture and docs updates

## Tests
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run