### PR TITLE
release: prepare v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">PR Test Guard</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.0-brightgreen.svg" alt="release v0.2.0" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/release-v0.2.1-brightgreen.svg" alt="release v0.2.1" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **Lightweight, rule-based test-quality checks for pull requests.**
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.0` adds AST-scoped targeted probe generation on top of the direct real-PR analyzer and reusable GitHub Action.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.1` adds PTG005 false-positive reduction for constrained dependency mocks on top of the direct real-PR analyzer, reusable GitHub Action, and AST-scoped targeted probes.
 
 | | |
 | --- | --- |
@@ -71,7 +71,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tigerless-labs/pr-test-guard@v0.2.0
+      - uses: tigerless-labs/pr-test-guard@v0.2.1
         with:
           base: origin/${{ github.base_ref }}
 ```
@@ -79,7 +79,7 @@ jobs:
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.2.0
+      - uses: tigerless-labs/pr-test-guard@v0.2.1
         with:
           base: origin/${{ github.base_ref }}
           coverage: coverage.xml
@@ -121,18 +121,19 @@ The direct `check` command currently emits six PR-scoped rule families:
 | `PTG002` | A changed Python line is uncovered in the supplied coverage XML. |
 | `PTG003` | A newly added assertion has an obviously weak existence/truthiness shape. |
 | `PTG004` | A test was deleted, skipped/xfail-marked, or lost assertions. |
-| `PTG005` | A mock directly replaces a changed Python symbol, or a changed test mocks an internal dependency called on a changed production line. |
+| `PTG005` | A mock directly replaces a changed Python symbol, or a changed test mocks an unconstrained internal dependency called on a changed production line. |
 | `PTG006` | An opt-in bounded targeted probe survives the configured tests. |
 
 These are review-oriented signals. Heuristic findings such as `PTG003` and `PTG005` are advisory by default rather than automatic reasons to block a merge. The older fixture runner retains its research-prototype labels internally so existing regression cases keep working.
 
 ## Current Runner
 
-The repository ships four executable Python/pytest regression fixtures under `cases/python/`:
+The repository ships executable Python/pytest regression fixtures under `cases/python/`:
 
 - `weak_assertion_001`
 - `issue_test_mismatch_001`
 - `mocked_core_path_001`
+- `legitimate_helper_mock_001`
 - `evidence_complete_001`
 
 Each fixture includes a small PR-like change, executable code, tests, change intent, and expected rule output. The expected output is used for regression testing of the tool itself; it is not presented as a public benchmark or a human-labeled comparison dataset.
@@ -176,7 +177,15 @@ The reusable `action.yml` calls the same CLI/core. There is no separate hosted a
 
 ## Mock and Probe Boundaries
 
-The current mock detector uses a lightweight Python semantic layer before matching. It recognizes explicit patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, resolves common import aliases, preserves class/method qualified names, and normalizes common `src/` layouts. It then adds a bounded relationship pass: direct changed-symbol mocks remain visible, while mocks in tests changed by the PR can also be related to **direct internal dependencies whose call sites are themselves changed by the PR**. Explicit imported dependencies that resolve outside the repository are treated as external-boundary candidates and suppressed from PTG005 warnings. Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural relationship evidence does not prove that a mock is inappropriate.
+The current mock detector uses a lightweight Python semantic layer before matching. It recognizes explicit patterns such as `patch`, `patch.object`, `monkeypatch.setattr`, and `mocker.patch`, resolves common import aliases, preserves class/method qualified names, and normalizes common `src/` layouts.
+
+PTG005 then applies three bounded layers:
+
+- direct changed-symbol mocks remain the highest-confidence warning;
+- explicitly imported external dependencies are treated as external-boundary candidates and suppressed from warnings;
+- changed tests that mock direct internal dependencies called on changed production lines are warned only when the mock is not constrained by an interaction assertion, owner return assertion, or owner exception assertion.
+
+Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural and test-semantics evidence does not prove that a mock is inappropriate.
 
 The targeted probe generator is deliberately limited and AST-scoped. It covers a small set of status-code returns, boolean return flips, and comparison-boundary changes on lines added by the current PR while avoiding string/comment matches and unstable multi-line rewrites. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
 
@@ -215,17 +224,17 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
-- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.0` release.
+- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.1` release.
 
 ## Current Scope
 
-Version `0.2.0` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Version `0.2.1` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;
 - obvious weak assertions added in changed tests;
 - suspicious test deletion, skip/xfail, or assertion removal;
-- lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites;
+- lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites, with constrained dependency mocks suppressed from PTG005 warnings;
 - optional bounded targeted probes that survive an explicit test command.
 
 It still does **not** include:
@@ -237,7 +246,7 @@ It still does **not** include:
 - safe privileged execution of untrusted PR code;
 - GitHub API ingestion or a hosted service.
 
-The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures. PTG005 now combines symbol identity with a deliberately bounded direct-dependency pass; later work should focus on real-PR precision, related-test selection, and only then optional deeper semantic assistance where deterministic relationships remain ambiguous.
+The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures. PTG005 now combines symbol identity, bounded direct-dependency relationships, and constrained dependency-mock suppression; later work should focus on real-PR precision, related-test selection, and only then optional deeper semantic assistance where deterministic relationships remain ambiguous.
 
 ## License
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -59,6 +59,8 @@ Mocks are neutral. The current structural detector raises a candidate when an ex
 
 A mock candidate should tell a reviewer where to look; it should not automatically fail a PR. A dependency mock that constrains the changed owner's interaction contract, return value, or exception behavior is treated differently from a mock that simply replaces behavior and then makes a weak existence assertion.
 
+The constrained dependency check is deliberately narrow. It looks for inspectable test evidence such as `assert_called_once_with`, `assert_called_with`, `call_args` / `call_count` assertions, non-weak assertions over the changed owner result, or `pytest.raises` around the owner call. It does not infer full business intent or decide that a mock is inherently appropriate.
+
 ### Counterfactual evidence
 
 The direct checker can execute a small set of deterministic behavior weakenings against changed Python lines. This path is opt-in through `--deep`, requires an explicit test command, and runs in an isolated Git worktree. Surviving probes can strengthen a test-quality warning.
@@ -73,7 +75,7 @@ The direct checker uses six stable rule ids for the current Python/pytest scope:
 - `PTG002` — changed Python line uncovered in a supplied coverage XML;
 - `PTG003` — possible weak assertion added in a changed test;
 - `PTG004` — suspicious test deletion, skip/xfail, or assertion removal;
-- `PTG005` — a mock directly replaces a changed Python symbol, or a changed test mocks an internal dependency called on a changed production line;
+- `PTG005` — a mock directly replaces a changed Python symbol, or a changed test mocks an unconstrained internal dependency called on a changed production line;
 - `PTG006` — bounded targeted probe survives the configured tests.
 
 Each result includes a rule id, advisory severity, file/line where available, a short message, and evidence text. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.
@@ -94,6 +96,6 @@ CI integration should be advisory by default. Repositories may later opt into st
 
 ## Current Limits
 
-Version `0.2.0` provides a repository-native `check` command, a reusable GitHub Action, and AST-scoped targeted probes for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
+Version `0.2.1` provides a repository-native `check` command, a reusable GitHub Action, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -51,7 +51,7 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
   with:
     fetch-depth: 0
 
-- uses: tigerless-labs/pr-test-guard@v0.2.0
+- uses: tigerless-labs/pr-test-guard@v0.2.1
   with:
     base: origin/${{ github.base_ref }}
 ```

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,61 @@
+# PR Test Guard v0.2.1
+
+Version `0.2.1` is a patch release focused on PTG005 false-positive reduction.
+
+## What Changed
+
+- PTG005 still warns when a mock directly replaces a Python symbol changed by the PR.
+- Explicit external-boundary dependency mocks remain suppressed from PTG005 warnings.
+- Changed tests that mock direct internal dependencies called on changed production lines are now suppressed when the test constrains the changed owner through:
+  - mock interaction assertions such as `assert_called_once_with` or `assert_called_with`;
+  - `call_args` or `call_count` assertions;
+  - non-weak assertions over the changed owner result;
+  - `pytest.raises` around the changed owner call.
+- Added `legitimate_helper_mock_001` as a PTG005 negative-control fixture.
+
+## Why It Matters
+
+Mocking a dependency is not automatically weak test evidence. Some tests use a
+mock as an interaction boundary while still asserting the behavior changed by the
+PR. PTG005 now keeps direct changed-symbol mocks visible, but reduces warnings
+for dependency mocks that are constrained by inspectable test assertions.
+
+## Behavior Examples
+
+Still warns:
+
+```text
+@patch("service.charge")
+def test_charge(mock_charge):
+    ...
+```
+
+Suppressed as constrained dependency evidence:
+
+```text
+@patch("service.send_payload")
+def test_process(mock_send):
+    process_payload({"id": "42"})
+    mock_send.assert_called_once_with({"id": "42", "source": "api"})
+```
+
+Still warns when unconstrained:
+
+```text
+@patch("service.send_payload")
+def test_process(mock_send):
+    mock_send.return_value = True
+    assert process_payload({"id": "42"}) is not None
+```
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest tests
+.venv/bin/python -m pr_test_guard validate-cases --run
+```
+
+## Compatibility
+
+The default path remains deterministic and offline. `--deep` behavior is
+unchanged, and findings remain advisory by default.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,15 +2,15 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Version `0.2.0` keeps the first public-ready shape from `0.1.0` and adds AST-scoped targeted probe generation for the optional deep path.
+Version `0.2.1` keeps the first public-ready shape from `0.1.0`, adds AST-scoped targeted probe generation for the optional deep path, and reduces PTG005 false positives for constrained dependency mocks.
 
-## What Exists in 0.2.0
+## What Exists in 0.2.1
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
 - optional `coverage.py` XML input for changed-line coverage signals;
 - obvious weak-assertion and test-weakening checks;
-- explicit Python mock-boundary candidates on changed symbols;
+- explicit Python mock-boundary candidates on changed symbols and unconstrained changed dependency mocks;
 - opt-in AST-scoped bounded targeted probes in an isolated Git worktree;
 - text, JSON, and GitHub Actions output;
 - reusable root `action.yml` with advisory warnings/job summary;
@@ -21,7 +21,7 @@ The fixture runner is development infrastructure for the tool. It is not the pro
 
 ## Current Main: PTG005 Semantic Lite
 
-The PTG005 precision work remains deterministic and offline, with two bounded layers.
+The PTG005 precision work remains deterministic and offline, with three bounded layers.
 
 **Identity resolution**:
 
@@ -42,7 +42,13 @@ The PTG005 precision work remains deterministic and offline, with two bounded la
 - recognize explicitly imported external dependencies and suppress those external-boundary candidates;
 - keep unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved relationships out of the warning path.
 
-This layer improves **structural relationship precision**, not business-intent understanding. It still does not decide whether a mock is appropriate, build a repository-wide call graph, or infer dynamic Python types. PTG005 remains advisory. Real-PR dogfooding should measure whether the relationship layer removes low-value warnings while retaining direct changed-symbol and changed-internal-dependency cases.
+**Constrained dependency mocks**:
+
+- keep direct changed-symbol mocks as warnings even when the test asserts mock interaction;
+- suppress internal dependency mock candidates when changed tests constrain the owner behavior through mock interaction assertions, owner result assertions, or owner exception assertions;
+- keep weak existence assertions, unconstrained mock return values, and ambiguous owner behavior in the warning path.
+
+This layer improves **structural and test-semantics precision**, not business-intent understanding. It still does not decide whether a mock is appropriate, build a repository-wide call graph, or infer dynamic Python types. PTG005 remains advisory. Real-PR dogfooding should measure whether the relationship layer removes low-value warnings while retaining direct changed-symbol and unconstrained changed-internal-dependency cases.
 
 ## Product Principles
 

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -94,7 +94,7 @@ Human-readable report for the fixture. Findings are review signals and do not ce
 
 ## Stability
 
-Version `0.2.0` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
+Version `0.2.1` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
 
 Changes should preserve two properties:
 

--- a/pr_test_guard/version.py
+++ b/pr_test_guard/version.py
@@ -1,3 +1,3 @@
 """Project version."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-test-guard"
-version = "0.2.0"
+version = "0.2.1"
 description = "Lightweight, rule-based test-quality checks for pull requests."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import pr_test_guard
+
+
+def test_package_version_is_current() -> None:
+    assert pr_test_guard.__version__ == "0.2.1"


### PR DESCRIPTION
## Summary
- bump package and public docs to v0.2.1
- document PTG005 constrained dependency-mock suppression from the latest main behavior
- add v0.2.1 release notes and a version sync test

## Tests
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run