### PR TITLE
test: add PTG006 probe validation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ PTG005 then applies three bounded layers:
 
 Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural and test-semantics evidence does not prove that a mock is inappropriate.
 
-The targeted probe generator is deliberately limited and AST-scoped. It covers a small set of status-code returns, boolean return flips, and comparison-boundary changes on lines added by the current PR while avoiding string/comment matches and unstable multi-line rewrites. A `PTG006` signal requires an actual rerun of the user-supplied test command in an isolated Git worktree.
+The targeted probe generator is deliberately limited and AST-scoped. It covers a small set of status-code returns, boolean return flips, and comparison-boundary changes on lines added by the current PR while avoiding string/comment matches and unstable multi-line rewrites. A generated probe is not itself a finding: `PTG006` is emitted only when the configured tests pass at baseline and a supported probe survives an actual rerun in an isolated Git worktree.
 
 These deeper signals are part of the product's differentiation beyond patch coverage. Mock-boundary analysis stays static and advisory. Targeted probes are bounded, PR-scoped, and opt-in through `--deep` because they rerun repository tests. The goal is not a full mutation-testing campaign; it is a small number of review-focused probes against code changed by the current PR.
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -65,7 +65,7 @@ The constrained dependency check is deliberately narrow. It looks for inspectabl
 
 The direct checker can execute a small set of deterministic behavior weakenings against changed Python lines. This path is opt-in through `--deep`, requires an explicit test command, and runs in an isolated Git worktree. Surviving probes can strengthen a test-quality warning.
 
-This is a bounded PR-scoped signal, not a full mutation-testing campaign or repository-wide mutation score.
+This is a bounded PR-scoped signal, not a full mutation-testing campaign or repository-wide mutation score. A generated probe is only a candidate. If the baseline test command fails, PTG006 is skipped. If the configured tests kill the probe, no warning is emitted. Unsupported shapes such as response constructors, symbolic HTTP status constants, and unstable multi-line rewrites remain quiet by design.
 
 ## Finding Model
 

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -62,7 +62,7 @@ The Action emits GitHub warning annotations and appends a job summary. Findings 
 
 `--deep` is opt-in because it executes the repository's configured test command. PR Test Guard first creates an isolated Git worktree at `HEAD`, verifies that the unmodified test command passes, and only then applies a bounded number of supported probes.
 
-This is intentionally different from a full mutation-testing campaign: the probe set is small, scoped to changed Python lines, and used as reviewer evidence rather than as a repository-wide mutation score.
+This is intentionally different from a full mutation-testing campaign: the probe set is small, scoped to changed Python lines, and used as reviewer evidence rather than as a repository-wide mutation score. Killed probes are treated as useful test sensitivity and do not produce PTG006 warnings. Unsupported probe shapes are skipped rather than guessed.
 
 ## Normalized Bundle Compatibility
 

--- a/docs/rule-fixtures.md
+++ b/docs/rule-fixtures.md
@@ -49,6 +49,7 @@ Examples worth adding include:
 - behavior change with existing-test coverage vs. truly missing tests;
 - legitimate dependency mock vs. mocked core behavior;
 - weak non-null assertion vs. a non-null assertion that is actually the intended contract;
+- targeted probe survivor vs. a nearby test that kills the same probe;
 - intentional test deletion vs. suspicious coverage reduction.
 
 These controls are more useful for product quality than a large synthetic leaderboard.

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -578,6 +578,17 @@ def run_shell(command: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, cwd=cwd, shell=True, capture_output=True, text=True)
 
 
+def remove_python_bytecode(path: Path) -> None:
+    pycache = path.parent / "__pycache__"
+    if not pycache.is_dir():
+        return
+    for compiled in pycache.glob(f"{path.stem}.*.pyc"):
+        try:
+            compiled.unlink()
+        except OSError:
+            pass
+
+
 def targeted_probe_findings(
     repo_root: Path,
     changed: dict[str, list[dict[str, Any]]],
@@ -625,9 +636,11 @@ def targeted_probe_findings(
                     continue
                 lines[index] = lines[index].replace(probe["original"], probe["replacement"], 1)
                 path.write_text("".join(lines), encoding="utf-8")
+                remove_python_bytecode(path)
                 summary["applied"] += 1
                 result = run_shell(test_command, worktree)
                 path.write_text(original_text, encoding="utf-8")
+                remove_python_bytecode(path)
                 if result.returncode == 0:
                     summary["survived"] += 1
                     findings.append(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -132,6 +132,94 @@ def test_targeted_probe_survivor_runs_in_isolated_worktree(tmp_path: Path) -> No
     assert run_worktree_list(repo) == 1
 
 
+def test_strong_status_assertion_kills_targeted_probe(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def status(ok):\n    return 400\n")
+    write(repo / "tests/test_app.py", "from app import status\n\ndef test_status():\n    assert status(False) == 400\n")
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def status(ok):\n    if not ok:\n        return 400\n    return 200\n")
+    write(
+        repo / "tests/test_app.py",
+        "from app import status\n\n"
+        "def test_status():\n    assert status(False) == 400\n\n"
+        "def test_success_status():\n    assert status(True) == 200\n",
+    )
+    commit_all(repo, "add branch")
+
+    result = analyze_repository(
+        repo,
+        base="HEAD~1",
+        deep=True,
+        test_command=f"{sys.executable} -m pytest -q",
+        max_probes=1,
+    )
+    assert "PTG006" not in rule_ids(result)
+    assert result.probe_summary["baseline_passed"] is True
+    assert result.probe_summary["generated"] == 1
+    assert result.probe_summary["applied"] == 1
+    assert result.probe_summary["survived"] == 0
+    assert run_worktree_list(repo) == 1
+
+
+def test_targeted_probe_skips_when_baseline_command_fails(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def status():\n    return 200\n")
+    write(repo / "tests/test_app.py", "from app import status\n\ndef test_status():\n    assert status() == 200\n")
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def status():\n    return 404\n")
+    write(repo / "tests/test_app.py", "from app import status\n\ndef test_status():\n    assert status() == 200\n")
+    commit_all(repo, "break status")
+
+    result = analyze_repository(
+        repo,
+        base="HEAD~1",
+        deep=True,
+        test_command=f"{sys.executable} -m pytest -q",
+        max_probes=1,
+    )
+    assert "PTG006" not in rule_ids(result)
+    assert result.probe_summary["baseline_passed"] is False
+    assert result.probe_summary["generated"] == 1
+    assert result.probe_summary["applied"] == 0
+    assert result.probe_summary["survived"] == 0
+    assert "PTG006 skipped: the configured test command fails on the unmodified PR checkout." in result.notes
+    assert run_worktree_list(repo) == 1
+
+
+def test_targeted_probe_respects_max_probes_limit(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def missing():\n    return 404\n\ndef forbidden():\n    return 403\n")
+    write(
+        repo / "tests/test_app.py",
+        "from app import forbidden, missing\n\n"
+        "def test_statuses():\n    assert missing() is not None\n    assert forbidden() is not None\n",
+    )
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def missing():\n    return 404\n\ndef forbidden():\n    return 403\n\ndef changed():\n    return True\n")
+    write(
+        repo / "tests/test_app.py",
+        "from app import changed, forbidden, missing\n\n"
+        "def test_statuses():\n    assert missing() is not None\n    assert forbidden() is not None\n    assert changed() is not None\n",
+    )
+    commit_all(repo, "add changed probes")
+
+    result = analyze_repository(
+        repo,
+        base="HEAD~1",
+        deep=True,
+        test_command=f"{sys.executable} -m pytest -q",
+        max_probes=1,
+    )
+    assert result.probe_summary["generated"] == 1
+    assert result.probe_summary["applied"] == 1
+    assert result.probe_summary["survived"] == 1
+    assert len([item for item in result.findings if item.rule_id == "PTG006"]) == 1
+    assert run_worktree_list(repo) == 1
+
+
 def run_worktree_list(repo: Path) -> int:
     result = subprocess.run(
         ["git", "worktree", "list", "--porcelain"],

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -46,6 +46,52 @@ def test_generates_comparison_probe_without_spacing_assumptions(tmp_path: Path) 
     ]
 
 
+def test_generates_comparison_probe_inside_if_condition(tmp_path: Path) -> None:
+    write(
+        tmp_path / "app.py",
+        "def status(amount):\n"
+        "    if amount >= 0:\n"
+        "        return 200\n"
+        "    return 400\n",
+    )
+
+    probes = generate_probes(tmp_path, {"app.py": [{"line": 2, "content": "    if amount >= 0:"}]}, max_probes=3)
+
+    assert probes == [
+        {
+            "id": "P1",
+            "file": "app.py",
+            "line": 2,
+            "original": "amount >= 0",
+            "replacement": "amount > 0",
+            "rationale": "weaken inclusive lower-bound comparison",
+            "kind": "comparison_boundary",
+        }
+    ]
+
+
+def test_chained_comparison_generates_single_stable_probe(tmp_path: Path) -> None:
+    write(tmp_path / "app.py", "def valid(amount, limit):\n    return 0 <= amount <= limit\n")
+
+    probes = generate_probes(
+        tmp_path,
+        {"app.py": [{"line": 2, "content": "    return 0 <= amount <= limit"}]},
+        max_probes=3,
+    )
+
+    assert probes == [
+        {
+            "id": "P1",
+            "file": "app.py",
+            "line": 2,
+            "original": "0 <= amount <= limit",
+            "replacement": "0 < amount <= limit",
+            "rationale": "weaken inclusive upper-bound comparison",
+            "kind": "comparison_boundary",
+        }
+    ]
+
+
 def test_generates_boolean_return_probe(tmp_path: Path) -> None:
     write(tmp_path / "app.py", "def enabled():\n    return True\n")
 
@@ -54,6 +100,68 @@ def test_generates_boolean_return_probe(tmp_path: Path) -> None:
     assert probes[0]["original"] == "return True"
     assert probes[0]["replacement"] == "return False"
     assert probes[0]["kind"] == "boolean_return"
+
+
+def test_response_constructor_status_code_is_not_a_probe_candidate(tmp_path: Path) -> None:
+    write(
+        tmp_path / "app.py",
+        "class Response:\n"
+        "    def __init__(self, status_code):\n"
+        "        self.status_code = status_code\n\n"
+        "def status():\n"
+        "    return Response(status_code=404)\n",
+    )
+
+    probes = generate_probes(
+        tmp_path,
+        {"app.py": [{"line": 6, "content": "    return Response(status_code=404)"}]},
+        max_probes=3,
+    )
+
+    assert probes == []
+
+
+def test_http_status_symbol_return_is_not_a_probe_candidate(tmp_path: Path) -> None:
+    write(
+        tmp_path / "app.py",
+        "from http import HTTPStatus\n\n"
+        "def status():\n"
+        "    return HTTPStatus.NOT_FOUND\n",
+    )
+
+    probes = generate_probes(
+        tmp_path,
+        {"app.py": [{"line": 4, "content": "    return HTTPStatus.NOT_FOUND"}]},
+        max_probes=3,
+    )
+
+    assert probes == []
+
+
+def test_max_probes_preserves_stable_order(tmp_path: Path) -> None:
+    write(
+        tmp_path / "app.py",
+        "def first():\n"
+        "    return 404\n\n"
+        "def second():\n"
+        "    return False\n",
+    )
+
+    probes = generate_probes(
+        tmp_path,
+        {
+            "app.py": [
+                {"line": 2, "content": "    return 404"},
+                {"line": 5, "content": "    return False"},
+            ]
+        },
+        max_probes=1,
+    )
+
+    assert len(probes) == 1
+    assert probes[0]["id"] == "P1"
+    assert probes[0]["line"] == 2
+    assert probes[0]["kind"] == "return_status_code"
 
 
 def test_string_and_comment_text_do_not_generate_probes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add generator controls for if-condition comparisons, chained comparisons, unsupported HTTP status shapes, and max-probe ordering
- add deep-mode tests for killed probes, baseline failures, survivor behavior, and max-probe limits
- document PTG006 candidate vs finding behavior and skipped unsupported shapes

## Tests
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run