### PR TITLE
test: add dogfood-derived PTG005 controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The repository ships executable Python/pytest regression fixtures under `cases/p
 - `issue_test_mismatch_001`
 - `mocked_core_path_001`
 - `legitimate_helper_mock_001`
+- `unconstrained_helper_mock_001`
 - `evidence_complete_001`
 
 Each fixture includes a small PR-like change, executable code, tests, change intent, and expected rule output. The expected output is used for regression testing of the tool itself; it is not presented as a public benchmark or a human-labeled comparison dataset.
@@ -184,6 +185,8 @@ PTG005 then applies three bounded layers:
 - direct changed-symbol mocks remain the highest-confidence warning;
 - explicitly imported external dependencies are treated as external-boundary candidates and suppressed from warnings;
 - changed tests that mock direct internal dependencies called on changed production lines are warned only when the mock is not constrained by an interaction assertion, owner return assertion, or owner exception assertion.
+
+PTG005 evidence is emitted as stable key/value context, including the relationship type, mock style, target, resolution result, review reason, changed owner symbol, changed call line, and candidate dependency targets where available. Suppressed constrained-helper and external-boundary candidates are summarized in notes rather than hidden silently.
 
 Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural and test-semantics evidence does not prove that a mock is inappropriate.
 
@@ -246,7 +249,7 @@ It still does **not** include:
 - safe privileged execution of untrusted PR code;
 - GitHub API ingestion or a hosted service.
 
-The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring false-positive patterns into regression fixtures. PTG005 now combines symbol identity, bounded direct-dependency relationships, and constrained dependency-mock suppression; later work should focus on real-PR precision, related-test selection, and only then optional deeper semantic assistance where deterministic relationships remain ambiguous.
+The next milestone remains real-PR dogfooding: run the rules across varied repositories, record useful / false-positive / unclear signals, and turn recurring patterns into public-safe distilled controls rather than raw PR examples. PTG005 now combines symbol identity, bounded direct-dependency relationships, constrained dependency-mock suppression, and clearer relationship evidence; later work should focus on real-PR precision, related-test selection, and only then optional deeper semantic assistance where deterministic relationships remain ambiguous.
 
 ## License
 

--- a/cases/python/unconstrained_helper_mock_001/claim.json
+++ b/cases/python/unconstrained_helper_mock_001/claim.json
@@ -1,0 +1,11 @@
+{
+  "claims": [
+    {
+      "id": "C1",
+      "text": "Quoting a customer should use the helper-computed price in the returned quote.",
+      "trigger": "customer quote is requested",
+      "expected_outcome": "quote contains helper-computed price",
+      "source": "issue.md"
+    }
+  ]
+}

--- a/cases/python/unconstrained_helper_mock_001/expected_findings.json
+++ b/cases/python/unconstrained_helper_mock_001/expected_findings.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "unconstrained_helper_mock_001",
+  "claims": [
+    {
+      "claim_id": "C1",
+      "adequacy": "weak",
+      "findings": [
+        {
+          "type": "Weak Assertion",
+          "evidence_refs": [
+            "repo/tests/test_order_service.py:13"
+          ],
+          "rationale": "The changed test mocks the helper dependency and only asserts that the owner call returns a non-null value. The direct checker treats this as a PTG005 dependency-mock warning; the legacy fixture runner records the weak assertion signal."
+        }
+      ]
+    }
+  ]
+}

--- a/cases/python/unconstrained_helper_mock_001/issue.md
+++ b/cases/python/unconstrained_helper_mock_001/issue.md
@@ -1,0 +1,8 @@
+# Issue
+
+`quote` should ask the pricing helper for the customer's price and return that
+computed price in the quote payload.
+
+Mocking the helper is only useful when the test still constrains `quote`'s owner
+behavior. A test that only checks the owner result is present can miss whether
+the helper-computed value is used correctly.

--- a/cases/python/unconstrained_helper_mock_001/metadata.json
+++ b/cases/python/unconstrained_helper_mock_001/metadata.json
@@ -1,0 +1,9 @@
+{
+  "language": "python",
+  "test_framework": "pytest",
+  "fixture_kind": "executable_micro_pr",
+  "case_id": "unconstrained_helper_mock_001",
+  "case_family": "PTG005 Positive Control",
+  "direct_checker_rule": "PTG005",
+  "expected_output_source": "controlled_construction"
+}

--- a/cases/python/unconstrained_helper_mock_001/pr.patch
+++ b/cases/python/unconstrained_helper_mock_001/pr.patch
@@ -1,0 +1,23 @@
+diff --git a/order_service.py b/order_service.py
+--- a/order_service.py
++++ b/order_service.py
+@@ -5,2 +5,2 @@
+ def quote(customer_id: str) -> dict[str, int | str]:
+-    return {"customer_id": customer_id, "price": 10}
++    return {"customer_id": customer_id, "price": price_for_customer(customer_id)}
+diff --git a/tests/test_order_service.py b/tests/test_order_service.py
+--- a/tests/test_order_service.py
++++ b/tests/test_order_service.py
+@@ -1 +1,3 @@
++from unittest.mock import patch
++
+ from order_service import quote
+@@ -4,2 +6,8 @@
+ def test_quote_returns_base_price():
+     assert quote("cust_001") == {"customer_id": "cust_001", "price": 10}
++
++
++@patch("order_service.price_for_customer")
++def test_quote_has_any_price(mock_price):
++    mock_price.return_value = 12
++    assert quote("cust_001") is not None

--- a/cases/python/unconstrained_helper_mock_001/repo/order_service.py
+++ b/cases/python/unconstrained_helper_mock_001/repo/order_service.py
@@ -1,0 +1,6 @@
+def price_for_customer(customer_id: str) -> int:
+    return 10
+
+
+def quote(customer_id: str) -> dict[str, int | str]:
+    return {"customer_id": customer_id, "price": 10}

--- a/cases/python/unconstrained_helper_mock_001/repo/tests/test_order_service.py
+++ b/cases/python/unconstrained_helper_mock_001/repo/tests/test_order_service.py
@@ -1,0 +1,5 @@
+from order_service import quote
+
+
+def test_quote_returns_base_price():
+    assert quote("cust_001") == {"customer_id": "cust_001", "price": 10}

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -75,3 +75,14 @@ When the same sanitized category appears repeatedly as a `false_positive` or
 boundary. The fixture should use fictional code and stable names, and its
 expected output should define the intended behavior without copying details from
 the original PR.
+
+For rule PRs, the public artifact should be one of these forms:
+
+- a direct-check unit test that builds a tiny temporary Git repository;
+- an executable micro-PR fixture under `cases/python/`;
+- a sanitized aggregate/example record under `examples/dogfood-reviews/`;
+- documentation that explains the boundary without naming the original project.
+
+Do not commit a real external or private PR merely to justify a rule change. A
+distilled fixture is the normative artifact when it preserves the rule-relevant
+shape and removes project-specific details.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,7 @@ Version `0.2.2` keeps the first public-ready shape from `0.1.0`, adds AST-scoped
 - obvious weak-assertion and test-weakening checks;
 - explicit Python mock-boundary candidates on changed symbols and unconstrained changed dependency mocks;
 - opt-in AST-scoped bounded targeted probes in an isolated Git worktree;
+- dogfood-derived sanitized review examples and public-safe distilled PTG005 controls;
 - text, JSON, and GitHub Actions output;
 - reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
@@ -84,6 +85,11 @@ needs more context
 ```
 
 Use recurring false-positive patterns to add regression fixtures and tighten rules before expanding the rule family.
+
+Real pull requests should inform this work without becoming public fixtures.
+The public repository should contain sanitized summaries and fictional distilled
+controls that preserve the rule shape, not raw diffs, paths, symbols, URLs, CI
+logs, or agent traces from private projects.
 
 Priority cases:
 

--- a/docs/rule-fixtures.md
+++ b/docs/rule-fixtures.md
@@ -32,6 +32,7 @@ The `claim.json` shape is retained from the original prototype because current r
 - `issue_test_mismatch_001`: exercises a test that covers a different behavior path.
 - `mocked_core_path_001`: exercises an explicit mock that replaces changed behavior.
 - `legitimate_helper_mock_001`: negative control for a dependency mock with an interaction-contract assertion.
+- `unconstrained_helper_mock_001`: positive control for a changed test that mocks an internal helper called from a changed owner line but only checks a weak owner result.
 - `evidence_complete_001`: positive control where the targeted behavior is directly asserted.
 
 ## Positive and Negative Controls
@@ -53,6 +54,29 @@ Examples worth adding include:
 - intentional test deletion vs. suspicious coverage reduction.
 
 These controls are more useful for product quality than a large synthetic leaderboard.
+
+## Dogfood-Derived Controls
+
+Real pull requests can motivate a fixture, but the committed fixture should be a
+distilled control rather than a raw or lightly renamed copy. Preserve only the
+rule-relevant shape:
+
+- which rule fired;
+- whether reviewer feedback was useful, false positive, unclear, or needed more context;
+- the coarse path/symbol/dependency kinds;
+- the relationship shape that the rule must preserve or suppress.
+
+Then rewrite the scenario with fictional module names, paths, symbols,
+dependencies, and tests. The public fixture should stand alone as a minimal
+rule-boundary example; the private PR remains only local validation evidence.
+
+For PTG005, `legitimate_helper_mock_001` and
+`unconstrained_helper_mock_001` are a paired control:
+
+```text
+constrained helper mock with owner behavior evidence -> suppress PTG005
+unconstrained helper mock with weak owner evidence -> emit PTG005
+```
 
 ## Updating Expected Findings
 

--- a/examples/dogfood-reviews/ptg005-distilled-controls.json
+++ b/examples/dogfood-reviews/ptg005-distilled-controls.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "1",
+  "review_id": "ptg005_distilled_controls_001",
+  "source": {
+    "visibility": "sanitized_private_review",
+    "repo_alias": "repo_002",
+    "pr_alias": "pr_001"
+  },
+  "environment": {
+    "language": "python",
+    "test_framework": "pytest",
+    "coverage_supplied": false,
+    "deep_enabled": false,
+    "test_command_shape": "pytest"
+  },
+  "findings": [
+    {
+      "rule_id": "PTG005",
+      "review_label": "useful",
+      "category": "unconstrained_internal_helper_mock",
+      "path_kind": "test",
+      "symbol_kind": "function",
+      "dependency_kind": "internal",
+      "evidence_shape": "changed test mocks dependency called from changed line without owner outcome assertion",
+      "action": "keep_rule_behavior"
+    },
+    {
+      "rule_id": "PTG005",
+      "review_label": "false_positive",
+      "category": "constrained_internal_helper_mock",
+      "path_kind": "test",
+      "symbol_kind": "function",
+      "dependency_kind": "internal",
+      "evidence_shape": "changed test mocks dependency called from changed line and constrains owner behavior",
+      "action": "add_fixture"
+    }
+  ]
+}

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -440,6 +440,26 @@ def tracked_test_files(repo_root: Path) -> list[str]:
     return [line for line in tracked_python_files(repo_root) if is_test_path(line)]
 
 
+def mock_relation_evidence(
+    *,
+    relation: MockRelation,
+    style: str,
+    target: str,
+    resolved: str | None,
+    review_reason: str,
+    details: dict[str, str],
+) -> str:
+    parts = [
+        f"relation={relation.value}",
+        f"style={style}",
+        f"target={target}",
+        f"resolved={resolved or 'unresolved'}",
+        f"review_reason={review_reason}",
+    ]
+    parts.extend(f"{key}={value}" for key, value in details.items())
+    return "; ".join(parts)
+
+
 def mock_boundary_findings(
     repo_root: Path,
     changed: dict[str, list[dict[str, Any]]],
@@ -468,7 +488,7 @@ def mock_boundary_findings(
     findings: list[Finding] = []
     seen: set[tuple[str, int, str]] = set()
     suppressed_external = 0
-    suppressed_constrained = 0
+    suppressed_constrained: dict[str, int] = {}
 
     for rel_path in (line for line in python_files if is_test_path(line)):
         path = repo_root / rel_path
@@ -501,10 +521,16 @@ def mock_boundary_findings(
                             "A mock directly replaces a Python symbol changed by this PR; "
                             "review whether the real changed behavior is still exercised."
                         ),
-                        evidence=(
-                            f"relation={MockRelation.DIRECT_CHANGED_SYMBOL.value}; "
-                            f"{target.style} target={target.raw_target}; resolved={resolved}; "
-                            f"match={match_kinds}; changed symbol(s)={changed_names}"
+                        evidence=mock_relation_evidence(
+                            relation=MockRelation.DIRECT_CHANGED_SYMBOL,
+                            style=target.style,
+                            target=target.raw_target,
+                            resolved=resolved,
+                            review_reason="mock_replaces_changed_symbol",
+                            details={
+                                "match": match_kinds,
+                                "changed_symbol(s)": changed_names,
+                            },
                         ),
                     )
                 )
@@ -537,7 +563,7 @@ def mock_boundary_findings(
                 added_lines=changed_test_lines.get(rel_path, set()),
             )
             if constraint.constrained:
-                suppressed_constrained += 1
+                suppressed_constrained[constraint.reason] = suppressed_constrained.get(constraint.reason, 0) + 1
                 seen.add(key)
                 continue
             seen.add(key)
@@ -553,11 +579,17 @@ def mock_boundary_findings(
                         "A changed test mocks an internal dependency called on a line changed by this PR; "
                         "review whether the changed behavior is still exercised."
                     ),
-                    evidence=(
-                        f"relation={MockRelation.DIRECT_INTERNAL_DEPENDENCY.value}; "
-                        f"{target.style} target={target.raw_target}; resolved={resolved}; "
-                        f"changed symbol={owner.canonical_name}; changed call line={dependency.line}; "
-                        f"dependency target(s)={dependency_targets}"
+                    evidence=mock_relation_evidence(
+                        relation=MockRelation.DIRECT_INTERNAL_DEPENDENCY,
+                        style=target.style,
+                        target=target.raw_target,
+                        resolved=resolved,
+                        review_reason="changed_test_mocks_dependency_called_on_changed_line",
+                        details={
+                            "changed_symbol": owner.canonical_name,
+                            "changed_call_line": str(dependency.line),
+                            "dependency_target(s)": dependency_targets,
+                        },
                     ),
                 )
             )
@@ -568,9 +600,12 @@ def mock_boundary_findings(
             f"{suppressed_external} external-boundary mock candidate(s) on changed call sites."
         )
     if suppressed_constrained:
+        reasons = ", ".join(f"{reason}={count}" for reason, count in sorted(suppressed_constrained.items()))
+        total = sum(suppressed_constrained.values())
         notes.append(
             "PTG005: suppressed "
-            f"{suppressed_constrained} constrained dependency mock candidate(s) with interaction or owner-outcome assertions."
+            f"{total} constrained dependency mock candidate(s) with interaction or owner-outcome assertions "
+            f"({reasons})."
         )
     return findings
 
@@ -651,9 +686,11 @@ def targeted_probe_findings(
                             line=probe["line"],
                             message="A bounded targeted probe survived the configured tests; the tests may be insensitive to this changed behavior.",
                             evidence=(
+                                "baseline_passed=true; "
+                                f"probe_id={probe.get('id', 'unknown')}; "
                                 f"kind={probe.get('kind', 'unknown')}; "
-                                f"{probe['original'].strip()} -> {probe['replacement'].strip()} "
-                                f"({probe['rationale']})"
+                                f"mutation={probe['original'].strip()} -> {probe['replacement'].strip()}; "
+                                f"rationale={probe['rationale']}"
                             ),
                         )
                     )

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -129,6 +129,13 @@ def test_targeted_probe_survivor_runs_in_isolated_worktree(tmp_path: Path) -> No
     assert "PTG006" in rule_ids(result)
     assert result.probe_summary["baseline_passed"] is True
     assert result.probe_summary["survived"] == 1
+    findings = [item for item in result.findings if item.rule_id == "PTG006"]
+    assert len(findings) == 1
+    evidence = findings[0].evidence or ""
+    assert "baseline_passed=true" in evidence
+    assert "probe_id=P1" in evidence
+    assert "kind=return_status_code" in evidence
+    assert "mutation=return 400 -> return 200" in evidence
     assert run_worktree_list(repo) == 1
 
 

--- a/tests/test_dogfood_workflow.py
+++ b/tests/test_dogfood_workflow.py
@@ -129,7 +129,10 @@ def test_summarize_records_counts_labels_and_categories() -> None:
 def test_load_records_skips_schema_documents() -> None:
     records = summary_module.load_records(ROOT / "examples" / "dogfood-reviews")
 
-    assert [record["review_id"] for record in records] == ["sample_001"]
+    assert [record["review_id"] for record in records] == [
+        "ptg005_distilled_controls_001",
+        "sample_001",
+    ]
 
 
 def test_sanitize_preserves_existing_command_shape() -> None:

--- a/tests/test_mock_relationships.py
+++ b/tests/test_mock_relationships.py
@@ -59,9 +59,11 @@ def test_changed_test_mocking_changed_internal_callsite_is_reported(tmp_path: Pa
 
     findings = ptg005(analyze_repository(repo, base="HEAD~1"))
     assert len(findings) == 1
-    assert "relation=direct_internal_dependency" in (findings[0].evidence or "")
-    assert "changed symbol=service.charge" in (findings[0].evidence or "")
-    assert "dependency target(s)=service.calculate_retry" in (findings[0].evidence or "")
+    evidence = findings[0].evidence or ""
+    assert "relation=direct_internal_dependency" in evidence
+    assert "review_reason=changed_test_mocks_dependency_called_on_changed_line" in evidence
+    assert "changed_symbol=service.charge" in evidence
+    assert "dependency_target(s)=service.calculate_retry" in evidence
 
 
 def test_internal_dependency_mock_with_interaction_assertion_is_suppressed(tmp_path: Path) -> None:
@@ -94,7 +96,7 @@ def test_internal_dependency_mock_with_interaction_assertion_is_suppressed(tmp_p
     assert not ptg005(result)
     notes = [note for note in result.notes if note.startswith("PTG005: suppressed")]
     assert notes == [
-        "PTG005: suppressed 1 constrained dependency mock candidate(s) with interaction or owner-outcome assertions."
+        "PTG005: suppressed 1 constrained dependency mock candidate(s) with interaction or owner-outcome assertions (interaction_assertion=1)."
     ]
 
 
@@ -155,7 +157,9 @@ def test_internal_dependency_mock_with_only_weak_assertion_is_still_reported(tmp
 
     findings = ptg005(analyze_repository(repo, base="HEAD~1"))
     assert len(findings) == 1
-    assert "relation=direct_internal_dependency" in (findings[0].evidence or "")
+    evidence = findings[0].evidence or ""
+    assert "relation=direct_internal_dependency" in evidence
+    assert "review_reason=changed_test_mocks_dependency_called_on_changed_line" in evidence
 
 
 def test_direct_changed_symbol_mock_is_reported_even_with_interaction_assertion(tmp_path: Path) -> None:
@@ -178,7 +182,9 @@ def test_direct_changed_symbol_mock_is_reported_even_with_interaction_assertion(
 
     findings = ptg005(analyze_repository(repo, base="HEAD~1"))
     assert len(findings) == 1
-    assert "relation=direct_changed_symbol" in (findings[0].evidence or "")
+    evidence = findings[0].evidence or ""
+    assert "relation=direct_changed_symbol" in evidence
+    assert "review_reason=mock_replaces_changed_symbol" in evidence
 
 
 def test_patch_where_looked_up_matches_internal_imported_dependency(tmp_path: Path) -> None:
@@ -210,6 +216,7 @@ def test_patch_where_looked_up_matches_internal_imported_dependency(tmp_path: Pa
     assert len(findings) == 1
     evidence = findings[0].evidence or ""
     assert "relation=direct_internal_dependency" in evidence
+    assert "review_reason=changed_test_mocks_dependency_called_on_changed_line" in evidence
     assert "payment.retry.calculate_retry" in evidence
     assert "payment.service.calculate_retry" in evidence
 
@@ -380,6 +387,80 @@ def test_self_method_call_on_changed_line_is_internal_dependency(tmp_path: Path)
     assert len(findings) == 1
     assert "relation=direct_internal_dependency" in (findings[0].evidence or "")
     assert "service.PaymentService.normalize" in (findings[0].evidence or "")
+
+
+def test_dogfood_distilled_unconstrained_helper_mock_is_reported_with_context(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "order_service.py",
+        "def price_for_customer(customer_id):\n    return 10\n\n"
+        "def quote(customer_id):\n    return price_for_customer(customer_id)\n",
+    )
+    write(repo / "tests/test_order_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "order_service.py",
+        "def price_for_customer(customer_id):\n    return 10\n\n"
+        "def quote(customer_id):\n    price = price_for_customer(customer_id)\n    return {'customer_id': customer_id, 'price': price}\n",
+    )
+    write(
+        repo / "tests/test_order_service.py",
+        "from unittest.mock import patch\nfrom order_service import quote\n\n"
+        "@patch('order_service.price_for_customer')\n"
+        "def test_quote(mock_price):\n"
+        "    mock_price.return_value = 12\n"
+        "    result = quote('cust_001')\n"
+        "    assert result is not None\n",
+    )
+    commit_all(repo, "change")
+
+    findings = ptg005(analyze_repository(repo, base="HEAD~1"))
+
+    assert len(findings) == 1
+    evidence = findings[0].evidence or ""
+    assert "relation=direct_internal_dependency" in evidence
+    assert "review_reason=changed_test_mocks_dependency_called_on_changed_line" in evidence
+    assert "changed_symbol=order_service.quote" in evidence
+    assert "changed_call_line=5" in evidence
+    assert "dependency_target(s)=order_service.price_for_customer" in evidence
+
+
+def test_dogfood_distilled_helper_mock_with_owner_exception_assertion_is_suppressed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(
+        repo / "order_service.py",
+        "class EmptyQuote(ValueError):\n    pass\n\n"
+        "def price_for_customer(customer_id):\n    return 10\n\n"
+        "def quote(customer_id):\n    return price_for_customer(customer_id)\n",
+    )
+    write(repo / "tests/test_order_service.py", "def test_placeholder():\n    assert True\n")
+    commit_all(repo, "base")
+
+    write(
+        repo / "order_service.py",
+        "class EmptyQuote(ValueError):\n    pass\n\n"
+        "def price_for_customer(customer_id):\n    return 10\n\n"
+        "def quote(customer_id):\n    price = price_for_customer(customer_id)\n    if price <= 0:\n        raise EmptyQuote('missing price')\n    return price\n",
+    )
+    write(
+        repo / "tests/test_order_service.py",
+        "from unittest.mock import patch\nimport pytest\nfrom order_service import EmptyQuote, quote\n\n"
+        "@patch('order_service.price_for_customer')\n"
+        "def test_quote_rejects_empty_price(mock_price):\n"
+        "    mock_price.return_value = 0\n"
+        "    with pytest.raises(EmptyQuote):\n"
+        "        quote('cust_001')\n",
+    )
+    commit_all(repo, "change")
+
+    result = analyze_repository(repo, base="HEAD~1")
+
+    assert not ptg005(result)
+    notes = [note for note in result.notes if note.startswith("PTG005: suppressed")]
+    assert notes == [
+        "PTG005: suppressed 1 constrained dependency mock candidate(s) with interaction or owner-outcome assertions (owner_exception_assertion=1)."
+    ]
 
 
 def test_deep_self_attribute_chain_stays_unresolved(tmp_path: Path) -> None:

--- a/tests/test_mock_semantic.py
+++ b/tests/test_mock_semantic.py
@@ -123,7 +123,7 @@ def test_src_layout_uses_importable_module_name(tmp_path: Path) -> None:
 
     findings = ptg005(analyze_repository(repo, base="HEAD~1"))
     assert len(findings) == 1
-    assert "changed symbol(s)=foo.service.charge" in (findings[0].evidence or "")
+    assert "changed_symbol(s)=foo.service.charge" in (findings[0].evidence or "")
 
 
 def test_module_alias_resolves_patch_object_owner(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add stable key/value PTG005 relationship evidence and clearer constrained-mock suppression notes
- include PTG006 survivor context for baseline/probe id/kind/mutation
- add a public-safe dogfood-derived PTG005 control fixture and sanitized review example
- document the workflow for turning dogfood observations into distilled rule controls

## Validation
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- .venv/bin/python -m pr_test_guard run-cases --case unconstrained_helper_mock_001 --output-dir /tmp/pr-test-guard-unconstrained-artifacts-3
- git diff --cached --check