### PR TITLE
feat: add related test context

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ It currently models evidence that can help answer:
 - **Was behavior changed without clear test evidence?**
 - **Are changed executable lines actually covered?**
 - **Do the relevant assertions constrain the behavior they appear to test?**
+- **Which tests have deterministic relationships to changed Python symbols?**
 - **Do tests exercise a different path than the change they are meant to support?**
 - **Do mocks or patches appear to replace the behavior under review?**
 - **Can a limited counterfactual change survive the attached tests?**
@@ -190,6 +191,8 @@ PTG005 evidence is emitted as stable key/value context, including the relationsh
 
 Unchanged call sites, untouched tests, deep instance-attribute chains, and other unresolved dynamic relationships remain conservative. A `PTG005` result is still a **candidate signal**; structural and test-semantics evidence does not prove that a mock is inappropriate.
 
+The direct checker also reports related-test candidates using deterministic import, direct-call, mock-target, and test-name context. This makes findings easier to inspect without claiming that a related test fully validates the changed behavior.
+
 The targeted probe generator is deliberately limited and AST-scoped. It covers a small set of status-code returns, boolean return flips, and comparison-boundary changes on lines added by the current PR while avoiding string/comment matches and unstable multi-line rewrites. A generated probe is not itself a finding: `PTG006` is emitted only when the configured tests pass at baseline and a supported probe survives an actual rerun in an isolated Git worktree.
 
 These deeper signals are part of the product's differentiation beyond patch coverage. Mock-boundary analysis stays static and advisory. Targeted probes are bounded, PR-scoped, and opt-in through `--deep` because they rerun repository tests. The goal is not a full mutation-testing campaign; it is a small number of review-focused probes against code changed by the current PR.
@@ -237,6 +240,7 @@ Version `0.2.2` supports direct Python/pytest PR analysis from the current Git r
 - uncovered changed Python lines when a coverage XML report is supplied;
 - obvious weak assertions added in changed tests;
 - suspicious test deletion, skip/xfail, or assertion removal;
+- deterministic related-test context for changed Python symbols;
 - lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites, with constrained dependency mocks suppressed from PTG005 warnings;
 - optional bounded targeted probes that survive an explicit test command.
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -13,6 +13,7 @@ For a changed behavior, PR Test Guard may inspect:
 - changed production files and lines;
 - added, modified, removed, skipped, or weakened tests;
 - assertion shapes;
+- deterministic related-test candidates from imports, direct calls, test names, and mock targets;
 - changed-line coverage when available;
 - explicit mock or patch boundaries;
 - CI/test-run evidence;
@@ -53,6 +54,17 @@ A covered branch can still be backed by a weak assertion. A passing test can sti
 
 The current Python prototype extracts assertion structure and can flag obvious weak patterns. This is intentionally conservative. An assertion that looks weak syntactically can still be meaningful in a richer test context, so this class of signal should be advisory by default.
 
+### Related-test context
+
+The direct checker records candidate tests that have deterministic relationships
+to changed Python symbols. The current context layer recognizes exact import
+relationships, direct calls to changed symbols, supported mock targets, and test
+name tokens when another deterministic relationship already exists.
+
+This is context for review output, not a test-selection oracle. A related test
+candidate may still assert the wrong behavior, and no related candidate does not
+prove that coverage is missing.
+
 ### Mock-boundary evidence
 
 Mocks are neutral. The current structural detector raises a candidate when an explicit patch target overlaps changed code that appears central to the tested path, or when a changed test mocks an internal dependency called on a changed production line without a clear interaction or owner-outcome assertion.
@@ -78,7 +90,7 @@ The direct checker uses six stable rule ids for the current Python/pytest scope:
 - `PTG005` — a mock directly replaces a changed Python symbol, or a changed test mocks an unconstrained internal dependency called on a changed production line;
 - `PTG006` — bounded targeted probe survives the configured tests.
 
-Each result includes a rule id, advisory severity, file/line where available, a short message, and evidence text. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.
+Each result includes a rule id, advisory severity, file/line where available, a short message, and evidence text. The direct checker also emits related-test candidates as JSON context and a short text/GitHub summary. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.
 
 ## CLI and CI Boundary
 

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -36,11 +36,16 @@ The current Python/pytest path uses:
 - changed production and test files;
 - changed Python lines;
 - changed test assertions and skip/xfail markers;
+- deterministic related-test candidates from test imports, direct calls, test names, and mock targets;
 - tracked Python tests for symbol-resolved mock targets and bounded changed-call relationships;
 - optional `coverage.py` XML;
 - optional explicit test command for bounded targeted probes.
 
 Missing optional artifacts are reported as skipped checks, not silently converted into negative evidence.
+
+Related-test candidates are included to make output easier to inspect. They do
+not prove that a test validates the changed behavior, and they are not used as a
+merge-blocking policy.
 
 ## GitHub Action
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,7 @@ Version `0.2.2` keeps the first public-ready shape from `0.1.0`, adds AST-scoped
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
 - optional `coverage.py` XML input for changed-line coverage signals;
 - obvious weak-assertion and test-weakening checks;
+- deterministic related-test context for changed Python symbols;
 - explicit Python mock-boundary candidates on changed symbols and unconstrained changed dependency mocks;
 - opt-in AST-scoped bounded targeted probes in an isolated Git worktree;
 - dogfood-derived sanitized review examples and public-safe distilled PTG005 controls;
@@ -50,6 +51,18 @@ The PTG005 precision work remains deterministic and offline, with three bounded 
 - keep weak existence assertions, unconstrained mock return values, and ambiguous owner behavior in the warning path.
 
 This layer improves **structural and test-semantics precision**, not business-intent understanding. It still does not decide whether a mock is appropriate, build a repository-wide call graph, or infer dynamic Python types. PTG005 remains advisory. Real-PR dogfooding should measure whether the relationship layer removes low-value warnings while retaining direct changed-symbol and unconstrained changed-internal-dependency cases.
+
+## Current Main: Related Test Context
+
+The direct checker records candidate tests tied to changed symbols through exact
+imports, direct calls, supported mock targets, and test-name tokens when another
+deterministic relationship already exists. This gives findings and summaries a
+small amount of surrounding test context without claiming that the candidate
+test is sufficient.
+
+The context is intentionally conservative: same-name symbols from different
+modules stay unrelated, dynamic calls are not guessed, and business-intent
+mapping remains out of scope for the default path.
 
 ## Product Principles
 

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -23,6 +23,8 @@ from .mock_analysis import (
     extract_mock_targets,
     match_mock_target,
 )
+from .mock_analysis.mocks import build_import_table, resolve_dotted_target
+from .mock_analysis.symbols import PythonSymbol
 from .probes import generate_probes
 
 
@@ -53,6 +55,7 @@ class AnalysisResult:
     findings: list[Finding]
     notes: list[str]
     probe_summary: dict[str, Any]
+    related_tests: list["RelatedTestCandidate"]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -64,10 +67,31 @@ class AnalysisResult:
                 "test_files": sum(1 for item in self.files if is_test_path(item.path)),
                 "findings": len(self.findings),
                 "notes": len(self.notes),
+                "related_tests": len(self.related_tests),
             },
             "findings": [item.to_dict() for item in self.findings],
             "notes": self.notes,
             "probes": self.probe_summary,
+            "related_tests": [item.to_dict() for item in self.related_tests],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RelatedTestCandidate:
+    file: str
+    test_name: str
+    line: int
+    end_line: int
+    matched_symbols: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "test_name": self.test_name,
+            "line": self.line,
+            "matched_symbols": list(self.matched_symbols),
+            "reasons": list(self.reasons),
         }
 
 
@@ -218,7 +242,11 @@ def classify_assertion(node: ast.Assert) -> str:
     return type(test).__name__
 
 
-def weak_assertion_findings(repo_root: Path, files: list[FileDiff]) -> list[Finding]:
+def weak_assertion_findings(
+    repo_root: Path,
+    files: list[FileDiff],
+    related_tests: list[RelatedTestCandidate],
+) -> list[Finding]:
     findings: list[Finding] = []
     for diff in files:
         if not is_test_path(diff.path) or not diff.path.endswith(".py"):
@@ -241,6 +269,10 @@ def weak_assertion_findings(repo_root: Path, files: list[FileDiff]) -> list[Find
             if shape not in {"existence_or_none_check", "truthiness_check", "call_truthiness_check"}:
                 continue
             evidence = source_for_node(source, node)
+            related = related_tests_for_location(related_tests, file=diff.path, line=node.lineno)
+            if related:
+                related_symbols = sorted({symbol for item in related for symbol in item.matched_symbols})
+                evidence = f"{evidence}; related_symbol(s)={', '.join(related_symbols[:5])}"
             findings.append(
                 Finding(
                     rule_id="PTG003",
@@ -254,7 +286,7 @@ def weak_assertion_findings(repo_root: Path, files: list[FileDiff]) -> list[Find
     return findings
 
 
-def missing_test_change_findings(files: list[FileDiff]) -> list[Finding]:
+def missing_test_change_findings(files: list[FileDiff], related_tests: list[RelatedTestCandidate]) -> list[Finding]:
     production = [item for item in files if not is_test_path(item.path) and is_python_path(item.path)]
     test_changes = [item for item in files if is_test_path(item.path)]
     if not production or test_changes:
@@ -267,7 +299,7 @@ def missing_test_change_findings(files: list[FileDiff]) -> list[Finding]:
             file=first.path,
             line=first.added[0][0] if first.added else None,
             message="Production code changed, but this PR contains no test-file change. Existing tests may still cover it; review whether extra test evidence is needed.",
-            evidence=f"{len(production)} production file(s) changed; 0 test files changed",
+            evidence=f"{len(production)} production file(s) changed; 0 test files changed; {related_test_summary(related_tests)}",
         )
     ]
 
@@ -438,6 +470,135 @@ def tracked_python_files(repo_root: Path) -> list[str]:
 
 def tracked_test_files(repo_root: Path) -> list[str]:
     return [line for line in tracked_python_files(repo_root) if is_test_path(line)]
+
+
+def _symbol_tokens(symbol: PythonSymbol) -> set[str]:
+    text = f"{symbol.module} {symbol.qualname} {symbol.name}".replace(".", " ").replace("_", " ")
+    return {token for token in re.findall(r"[a-zA-Z0-9]+", text.lower()) if len(token) > 1}
+
+
+def _resolved_call_candidates(name: str, imports: dict[str, str]) -> set[str]:
+    resolved, _ = resolve_dotted_target(name, imports)
+    values = {name}
+    if resolved:
+        values.add(resolved)
+    return {item.strip(".") for item in values if item}
+
+
+def _import_reasons(imports: dict[str, str], symbol: PythonSymbol) -> set[str]:
+    reasons: set[str] = set()
+    for target in imports.values():
+        if target == symbol.canonical_name:
+            reasons.add("imports_changed_symbol")
+        elif target == symbol.module:
+            reasons.add("imports_changed_module")
+    return reasons
+
+
+def _call_reasons(test_node: ast.FunctionDef | ast.AsyncFunctionDef, imports: dict[str, str], symbol: PythonSymbol) -> set[str]:
+    reasons: set[str] = set()
+    for node in ast.walk(test_node):
+        if not isinstance(node, ast.Call):
+            continue
+        name = call_name(node)
+        if not name:
+            continue
+        if symbol.canonical_name in _resolved_call_candidates(name, imports):
+            reasons.add("direct_call_changed_symbol")
+    return reasons
+
+
+def _mock_reasons(
+    mock_targets: list[Any],
+    test_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    symbol: PythonSymbol,
+) -> set[str]:
+    reasons: set[str] = set()
+    start = int(getattr(test_node, "lineno", 0))
+    end = int(getattr(test_node, "end_lineno", start))
+    for target in mock_targets:
+        if not (start <= target.line <= end):
+            continue
+        if any(match.symbol.canonical_name == symbol.canonical_name for match in match_mock_target(target, [symbol])):
+            reasons.add("mocks_changed_symbol")
+    return reasons
+
+
+def collect_related_tests(
+    repo_root: Path,
+    changed: dict[str, list[dict[str, Any]]],
+    *,
+    test_files: list[str] | None = None,
+) -> list[RelatedTestCandidate]:
+    symbols = collect_changed_symbols(repo_root, changed)
+    if not symbols:
+        return []
+
+    candidates: list[RelatedTestCandidate] = []
+    paths = test_files if test_files is not None else tracked_test_files(repo_root)
+    for rel_path in paths:
+        path = repo_root / rel_path
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+
+        imports = build_import_table(tree, rel_path)
+        mock_targets = extract_mock_targets(source, tree, rel_path)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.name.startswith("test_"):
+                continue
+            matched_symbols: set[str] = set()
+            reasons: set[str] = set()
+            name_tokens = set(re.findall(r"[a-zA-Z0-9]+", node.name.lower()))
+            for symbol in symbols:
+                symbol_reasons = set()
+                symbol_reasons.update(_import_reasons(imports, symbol))
+                symbol_reasons.update(_call_reasons(node, imports, symbol))
+                symbol_reasons.update(_mock_reasons(mock_targets, node, symbol))
+                if symbol_reasons:
+                    matched_symbols.add(symbol.canonical_name)
+                    reasons.update(symbol_reasons)
+                    if name_tokens & _symbol_tokens(symbol):
+                        reasons.add("test_name_token")
+            if matched_symbols:
+                line = int(getattr(node, "lineno", 0))
+                candidates.append(
+                    RelatedTestCandidate(
+                        file=rel_path,
+                        test_name=node.name,
+                        line=line,
+                        end_line=int(getattr(node, "end_lineno", line)),
+                        matched_symbols=tuple(sorted(matched_symbols)),
+                        reasons=tuple(sorted(reasons)),
+                    )
+                )
+
+    return sorted(candidates, key=lambda item: (item.file, item.line, item.test_name))
+
+
+def related_test_summary(related_tests: list[RelatedTestCandidate]) -> str:
+    if not related_tests:
+        return "related_test_candidates=0"
+    symbols = sorted({symbol for item in related_tests for symbol in item.matched_symbols})
+    reasons = sorted({reason for item in related_tests for reason in item.reasons})
+    return (
+        f"related_test_candidates={len(related_tests)}; "
+        f"related_symbol(s)={', '.join(symbols[:5])}; "
+        f"reason(s)={', '.join(reasons)}"
+    )
+
+
+def related_tests_for_location(
+    related_tests: list[RelatedTestCandidate],
+    *,
+    file: str,
+    line: int,
+) -> list[RelatedTestCandidate]:
+    return [item for item in related_tests if item.file == file and item.line <= line <= item.end_line]
 
 
 def mock_relation_evidence(
@@ -632,6 +793,7 @@ def targeted_probe_findings(
     test_command: str | None,
     max_probes: int,
     notes: list[str],
+    related_tests: list[RelatedTestCandidate],
 ) -> tuple[list[Finding], dict[str, Any]]:
     empty_summary = {"enabled": deep, "generated": 0, "applied": 0, "survived": 0, "baseline_passed": None}
     if not deep:
@@ -690,7 +852,8 @@ def targeted_probe_findings(
                                 f"probe_id={probe.get('id', 'unknown')}; "
                                 f"kind={probe.get('kind', 'unknown')}; "
                                 f"mutation={probe['original'].strip()} -> {probe['replacement'].strip()}; "
-                                f"rationale={probe['rationale']}"
+                                f"rationale={probe['rationale']}; "
+                                f"{related_test_summary(related_tests)}"
                             ),
                         )
                     )
@@ -728,11 +891,14 @@ def analyze_repository(
     files = parse_diff(repo_root, base)
     changed = changed_code_lines(files)
     notes: list[str] = []
+    related_tests = collect_related_tests(repo_root, changed)
+    if changed:
+        notes.append(f"Related test context: {related_test_summary(related_tests)}.")
 
     findings: list[Finding] = []
-    findings.extend(missing_test_change_findings(files))
+    findings.extend(missing_test_change_findings(files, related_tests))
     findings.extend(uncovered_line_findings(repo_root, changed, coverage_path, notes))
-    findings.extend(weak_assertion_findings(repo_root, files))
+    findings.extend(weak_assertion_findings(repo_root, files, related_tests))
     findings.extend(test_weakening_findings(repo_root, files))
     findings.extend(mock_boundary_findings(repo_root, changed, files, notes))
     probe_findings, probe_summary = targeted_probe_findings(
@@ -742,6 +908,7 @@ def analyze_repository(
         test_command=test_command,
         max_probes=max_probes,
         notes=notes,
+        related_tests=related_tests,
     )
     findings.extend(probe_findings)
 
@@ -758,6 +925,7 @@ def analyze_repository(
         findings=dedupe_findings(findings),
         notes=notes,
         probe_summary=probe_summary,
+        related_tests=related_tests,
     )
 
 

--- a/pr_test_guard/reporters.py
+++ b/pr_test_guard/reporters.py
@@ -26,6 +26,7 @@ def render_text(result: AnalysisResult) -> str:
         "─────────────",
         f"Base: {result.base}",
         f"Changed files: {len(result.files)} ({production} Python production, {tests} test)",
+        f"Related test candidates: {len(result.related_tests)}",
         "",
     ]
     if result.findings:
@@ -76,6 +77,7 @@ def github_summary(result: AnalysisResult) -> str:
         "## PR Test Guard",
         "",
         f"**{len(result.findings)} review signal(s)** found between `{result.base}` and `HEAD`.",
+        f"**{len(result.related_tests)} related test candidate(s)** identified from deterministic import/call/name context.",
         "",
     ]
     if result.findings:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from pr_test_guard.check import analyze_repository
+from pr_test_guard.reporters import render_json, render_text
 
 
 def run(*args: str, cwd: Path) -> None:
@@ -45,6 +46,51 @@ def test_missing_test_change_is_advisory_signal(tmp_path: Path) -> None:
 
     result = analyze_repository(repo, base="HEAD~1")
     assert "PTG001" in rule_ids(result)
+    finding = next(item for item in result.findings if item.rule_id == "PTG001")
+    assert "related_test_candidates=1" in (finding.evidence or "")
+    assert result.related_tests[0].matched_symbols == ("app.value",)
+    assert set(result.related_tests[0].reasons) == {
+        "direct_call_changed_symbol",
+        "imports_changed_symbol",
+        "test_name_token",
+    }
+    assert "Related test candidates: 1" in render_text(result)
+    assert '"related_tests"' in render_json(result)
+
+
+def test_related_context_tracks_module_import_without_direct_call(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "service.py", "def charge(amount):\n    return amount > 0\n")
+    write(repo / "tests/test_service.py", "import service\n\n\ndef test_service_imports():\n    assert service is not None\n")
+    commit_all(repo, "base")
+
+    write(repo / "service.py", "def charge(amount):\n    return amount >= 0\n")
+    commit_all(repo, "change production only")
+
+    result = analyze_repository(repo, base="HEAD~1")
+
+    assert len(result.related_tests) == 1
+    related = result.related_tests[0]
+    assert related.test_name == "test_service_imports"
+    assert related.matched_symbols == ("service.charge",)
+    assert related.reasons == ("imports_changed_module", "test_name_token")
+
+
+def test_related_context_ignores_same_token_from_different_module(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "payment.py", "def charge(amount):\n    return amount > 0\n")
+    write(repo / "email.py", "def charge(message):\n    return True\n")
+    write(repo / "tests/test_email.py", "from email import charge\n\n\ndef test_charge():\n    assert charge('hello') is True\n")
+    commit_all(repo, "base")
+
+    write(repo / "payment.py", "def charge(amount):\n    return amount >= 0\n")
+    commit_all(repo, "change payment")
+
+    result = analyze_repository(repo, base="HEAD~1")
+
+    assert result.related_tests == []
+    finding = next(item for item in result.findings if item.rule_id == "PTG001")
+    assert "related_test_candidates=0" in (finding.evidence or "")
 
 
 def test_weak_assertion_and_mock_boundary_are_detected(tmp_path: Path) -> None:
@@ -68,6 +114,8 @@ def test_weak_assertion_and_mock_boundary_are_detected(tmp_path: Path) -> None:
     ids = rule_ids(result)
     assert "PTG003" in ids
     assert "PTG005" in ids
+    weak = next(item for item in result.findings if item.rule_id == "PTG003")
+    assert "related_symbol(s)=payment.charge" in (weak.evidence or "")
 
 
 def test_test_skip_is_detected(tmp_path: Path) -> None:
@@ -136,6 +184,7 @@ def test_targeted_probe_survivor_runs_in_isolated_worktree(tmp_path: Path) -> No
     assert "probe_id=P1" in evidence
     assert "kind=return_status_code" in evidence
     assert "mutation=return 400 -> return 200" in evidence
+    assert "related_test_candidates=1" in evidence
     assert run_worktree_list(repo) == 1
 
 


### PR DESCRIPTION
## Summary
- add deterministic related-test candidates for changed Python symbols using imports, direct calls, supported mock targets, and guarded test-name context
- surface related-test counts in text/GitHub output and include full candidates in JSON
- carry the context into PTG001, PTG003, and PTG006 evidence where it helps explain what nearby tests exist
- document the boundary: this is review context, not a claim that a test is sufficient

## Validation
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- git diff --check