### PR TITLE
release: prepare v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">PR Test Guard</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.2-brightgreen.svg" alt="release v0.2.2" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/release-v0.2.3-brightgreen.svg" alt="release v0.2.3" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **Lightweight, rule-based test-quality checks for pull requests.**
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.2` fixes PTG006 probe rerun correctness around stale Python bytecode on top of the direct real-PR analyzer, reusable GitHub Action, PTG005 false-positive reduction, and AST-scoped targeted probes.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.3` adds deterministic related-test context and clearer PTG005/PTG006 evidence on top of the direct real-PR analyzer, reusable GitHub Action, PTG005 false-positive reduction, and AST-scoped targeted probes.
 
 | | |
 | --- | --- |
@@ -71,7 +71,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tigerless-labs/pr-test-guard@v0.2.2
+      - uses: tigerless-labs/pr-test-guard@v0.2.3
         with:
           base: origin/${{ github.base_ref }}
 ```
@@ -79,7 +79,7 @@ jobs:
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.2.2
+      - uses: tigerless-labs/pr-test-guard@v0.2.3
         with:
           base: origin/${{ github.base_ref }}
           coverage: coverage.xml
@@ -230,11 +230,11 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
-- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.2` release.
+- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.3` release.
 
 ## Current Scope
 
-Version `0.2.2` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Version `0.2.3` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -108,6 +108,6 @@ CI integration should be advisory by default. Repositories may later opt into st
 
 ## Current Limits
 
-Version `0.2.2` provides a repository-native `check` command, a reusable GitHub Action, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
+Version `0.2.3` provides a repository-native `check` command, a reusable GitHub Action, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -56,7 +56,7 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
   with:
     fetch-depth: 0
 
-- uses: tigerless-labs/pr-test-guard@v0.2.2
+- uses: tigerless-labs/pr-test-guard@v0.2.3
   with:
     base: origin/${{ github.base_ref }}
 ```

--- a/docs/releases/v0.2.3.md
+++ b/docs/releases/v0.2.3.md
@@ -1,0 +1,26 @@
+# PR Test Guard v0.2.3
+
+Version `0.2.3` is a patch release focused on reviewer context and evidence clarity for the direct PR checker.
+
+## What Changed
+
+- Added deterministic related-test candidates for changed Python symbols using imports, direct calls, supported mock targets, and guarded test-name context.
+- Included related-test context in JSON output and summarized candidate counts in text and GitHub output.
+- Added related-test context to PTG001, PTG003, and PTG006 evidence where it helps explain nearby test signals.
+- Improved PTG005 relationship evidence with stable key/value context and clearer constrained dependency-mock suppression notes.
+- Added public-safe dogfood-derived PTG005 controls, including an unconstrained helper-mock fixture and sanitized review example.
+
+## Compatibility
+
+- Advisory behavior remains unchanged; findings still do not fail a job by default.
+- The default checker still requires no LLM, API key, hosted service, or GitHub write permission.
+- Existing CLI and GitHub Action inputs remain compatible.
+- Related-test candidates are review context only. They do not prove that a test validates the changed behavior.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest tests
+.venv/bin/python -m pr_test_guard validate-cases --run
+git diff --check
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Version `0.2.2` keeps the first public-ready shape from `0.1.0`, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
+Version `0.2.3` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
 
-## What Exists in 0.2.2
+## What Exists in 0.2.3
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -94,7 +94,7 @@ Human-readable report for the fixture. Findings are review signals and do not ce
 
 ## Stability
 
-Version `0.2.2` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
+Version `0.2.3` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
 
 Changes should preserve two properties:
 

--- a/pr_test_guard/version.py
+++ b/pr_test_guard/version.py
@@ -1,3 +1,3 @@
 """Project version."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-test-guard"
-version = "0.2.2"
+version = "0.2.3"
 description = "Lightweight, rule-based test-quality checks for pull requests."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ import pr_test_guard
 
 
 def test_package_version_is_current() -> None:
-    assert pr_test_guard.__version__ == "0.2.2"
+    assert pr_test_guard.__version__ == "0.2.3"


### PR DESCRIPTION
## Summary
- prepare v0.2.3 after the related-test context and evidence improvements
- update package metadata, docs, Action examples, and release notes
- keep advisory behavior and existing CLI/Action usage unchanged

## Validation
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- .venv/bin/python -m pr_test_guard check --base origin/main
- git diff --check