### PR TITLE
feat: add configurable PR policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.3` adds deterministic related-test context and clearer PTG005/PTG006 evidence on top of the direct real-PR analyzer, reusable GitHub Action, PTG005 false-positive reduction, and AST-scoped targeted probes.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Current main adds configurable rule policy and richer GitHub output on top of the `0.2.3` related-test context release.
 
 | | |
 | --- | --- |
@@ -52,6 +52,29 @@ pr-test-guard check \
 
 Findings are advisory and a successful analysis exits `0` even when warnings are found. Operational errors such as an invalid base ref or malformed coverage file exit non-zero.
 
+To tune adoption in a repository, add `.pr-test-guard.yml`:
+
+```yaml
+rules:
+  PTG001: warn
+  PTG003: warn
+  PTG005: warn
+  PTG006: error
+
+policy:
+  fail_on: []
+
+paths:
+  ignore:
+    - "docs/**"
+    - "scripts/generated/**"
+
+related_tests:
+  max_candidates: 5
+```
+
+Rule actions are `off`, `warn`, or `error`. `off` suppresses matching findings, `warn` keeps the default advisory behavior, and `error` makes `pr-test-guard check` exit `1` when that rule triggers. `policy.fail_on` accepts rule ids that should be treated as error-level without repeating them under `rules`.
+
 To run the same analyzer automatically on pull requests, add a workflow such as:
 
 ```yaml
@@ -74,6 +97,7 @@ jobs:
       - uses: tigerless-labs/pr-test-guard@v0.2.3
         with:
           base: origin/${{ github.base_ref }}
+          config: .pr-test-guard.yml
 ```
 
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
@@ -86,6 +110,7 @@ Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflo
           deep: "true"
           test-command: pytest -q
           max-probes: "3"
+          fail-on: PTG006
 ```
 
 The existing regression-fixture commands remain available for development of PR Test Guard itself. Install the development extras first:
@@ -175,7 +200,7 @@ current Git repository + base ref + optional coverage/test command
 
 The older normalized bundle under `examples/real-pr-bundles/` remains as a development fixture and compatibility prototype for richer CI artifacts. It can include PR metadata, a diff, CI/test results, coverage, and optional change-intent context, but it is not required by the direct checker. See [Real PR Input](docs/real-pr-input.md).
 
-The reusable `action.yml` calls the same CLI/core. There is no separate hosted analysis service and no API key is required for the default path.
+The reusable `action.yml` calls the same CLI/core. There is no separate hosted analysis service and no API key is required for the default path. GitHub output is grouped by rule, includes related-test candidates up to the configured limit, and emits error annotations for rules configured as error-level policy.
 
 ## Mock and Probe Boundaries
 
@@ -234,7 +259,7 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 
 ## Current Scope
 
-Version `0.2.3` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Current main supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;
@@ -243,10 +268,10 @@ Version `0.2.3` supports direct Python/pytest PR analysis from the current Git r
 - deterministic related-test context for changed Python symbols;
 - lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites, with constrained dependency mocks suppressed from PTG005 warnings;
 - optional bounded targeted probes that survive an explicit test command.
+- configurable rule policy through `.pr-test-guard.yml`, `--config`, `--no-config`, and `--fail-on`.
 
 It still does **not** include:
 
-- configurable merge-blocking enforcement;
 - per-test coverage mapping;
 - broad business-intent assertion or mock classification;
 - automatic discovery of every repository's test command;

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: Optional path to a coverage.py XML report.
     required: false
     default: ""
+  config:
+    description: Optional path to a PR Test Guard config file.
+    required: false
+    default: ""
+  fail-on:
+    description: Comma-separated rule ids that should fail the Action when triggered.
+    required: false
+    default: ""
   deep:
     description: Enable bounded targeted probes. Requires test-command.
     required: false
@@ -69,6 +77,8 @@ runs:
       shell: bash
       env:
         INPUT_COVERAGE: ${{ inputs.coverage }}
+        INPUT_CONFIG: ${{ inputs.config }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
         INPUT_DEEP: ${{ inputs.deep }}
         INPUT_TEST_COMMAND: ${{ inputs.test-command }}
         INPUT_MAX_PROBES: ${{ inputs.max-probes }}
@@ -79,6 +89,14 @@ runs:
 
         if [[ -n "$INPUT_COVERAGE" ]]; then
           args+=(--coverage "$INPUT_COVERAGE")
+        fi
+
+        if [[ -n "$INPUT_CONFIG" ]]; then
+          args+=(--config "$INPUT_CONFIG")
+        fi
+
+        if [[ -n "$INPUT_FAIL_ON" ]]; then
+          args+=(--fail-on "$INPUT_FAIL_ON")
         fi
 
         if [[ "$INPUT_DEEP" == "true" ]]; then

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -31,6 +31,8 @@ Rules should prefer signals that are:
 4. **Cheap enough for CI** — lightweight checks should not require an expensive benchmark or hosted service.
 5. **Advisory when uncertain** — heuristics should surface risk without pretending to know the final merge decision.
 
+Detection and policy are separate. The checker identifies review signals; repository configuration decides whether a selected rule is hidden, advisory, or error-level for CI.
+
 ## Evidence Layers
 
 ### Test-diff evidence
@@ -90,7 +92,7 @@ The direct checker uses six stable rule ids for the current Python/pytest scope:
 - `PTG005` — a mock directly replaces a changed Python symbol, or a changed test mocks an unconstrained internal dependency called on a changed production line;
 - `PTG006` — bounded targeted probe survives the configured tests.
 
-Each result includes a rule id, advisory severity, file/line where available, a short message, and evidence text. The direct checker also emits related-test candidates as JSON context and a short text/GitHub summary. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.
+Each result includes a rule id, severity, file/line where available, a short message, and evidence text. Severity defaults to `warning`; `.pr-test-guard.yml` or `--fail-on` can promote selected rules to `error` or suppress them with `off`. The direct checker also emits related-test candidates as JSON context and a short text/GitHub summary. The older fixture runner retains its research-prototype labels only so existing regression fixtures remain stable during the transition.
 
 ## CLI and CI Boundary
 
@@ -104,10 +106,10 @@ PR Test Guard core
     -> GitHub Action wrapper
 ```
 
-CI integration should be advisory by default. Repositories may later opt into stricter enforcement for specific high-confidence rules or project-defined thresholds.
+CI integration should be advisory by default. Repositories can opt into stricter enforcement for selected rules with configuration while keeping heuristic detection inspectable and reversible.
 
 ## Current Limits
 
-Version `0.2.3` provides a repository-native `check` command, a reusable GitHub Action, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures.
+Current main provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -28,6 +28,41 @@ pr-test-guard check \
 
 The default path does not require a PR body, issue text, LLM output, or a custom JSON bundle.
 
+## Configuration
+
+`pr-test-guard check` automatically reads the first config file found at the repository root:
+
+```text
+.pr-test-guard.yml
+.pr-test-guard.yaml
+.pr-test-guard.json
+.pr-test-guard.toml
+```
+
+A minimal YAML config can tune rollout without changing rule detection:
+
+```yaml
+rules:
+  PTG001: warn
+  PTG003: off
+  PTG005: warn
+  PTG006: error
+
+policy:
+  fail_on: [PTG006]
+
+paths:
+  ignore:
+    - "docs/**"
+
+related_tests:
+  max_candidates: 5
+```
+
+Use `--config path/to/config.yml` to pass an explicit file, `--no-config` to run with the default advisory policy, and `--fail-on PTG006,PTG005` for a one-off CI override.
+
+Configuration is applied after detection. It controls which findings are shown and whether the command exits `1`; it does not make heuristic rules more certain.
+
 ## What the Direct Checker Reads
 
 The current Python/pytest path uses:
@@ -40,6 +75,7 @@ The current Python/pytest path uses:
 - tracked Python tests for symbol-resolved mock targets and bounded changed-call relationships;
 - optional `coverage.py` XML;
 - optional explicit test command for bounded targeted probes.
+- optional `.pr-test-guard.*` policy configuration.
 
 Missing optional artifacts are reported as skipped checks, not silently converted into negative evidence.
 
@@ -62,6 +98,26 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
 ```
 
 The Action emits GitHub warning annotations and appends a job summary. Findings are advisory by default and do not make the Action fail.
+
+To use repository policy:
+
+```yaml
+- uses: tigerless-labs/pr-test-guard@v0.2.3
+  with:
+    base: origin/${{ github.base_ref }}
+    config: .pr-test-guard.yml
+```
+
+To enforce a high-confidence rule without a config file:
+
+```yaml
+- uses: tigerless-labs/pr-test-guard@v0.2.3
+  with:
+    base: origin/${{ github.base_ref }}
+    fail-on: PTG006
+```
+
+Rules configured as `error` emit GitHub error annotations and make the Action fail after the summary is written. Warning rules remain advisory.
 
 ## Deep Probe Boundary
 
@@ -91,6 +147,6 @@ This bundle is no longer required for normal real-PR use.
 
 ## Security Boundary
 
-The static/default checker only reads repository content and Git history. Coverage is consumed only when explicitly supplied.
+The static/default checker only reads repository content, Git history, and an optional repository-local config file. Coverage is consumed only when explicitly supplied.
 
 Deep probes execute a test command chosen by the repository/user. In GitHub Actions, that execution therefore follows the trust boundary of the workflow that opted into it. PR Test Guard does not request repository write permission or secrets for its default advisory path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Version `0.2.3` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
+Current main keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
 
-## What Exists in 0.2.3
+## What Exists on Main
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
@@ -15,6 +15,7 @@ Version `0.2.3` keeps the first public-ready shape from `0.1.0`, adds determinis
 - opt-in AST-scoped bounded targeted probes in an isolated Git worktree;
 - dogfood-derived sanitized review examples and public-safe distilled PTG005 controls;
 - text, JSON, and GitHub Actions output;
+- `.pr-test-guard.*` configuration for rule `off` / `warn` / `error`, ignored paths, related-test display limits, and one-off `--fail-on` CI policy;
 - reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
 - normalized real-PR bundle compatibility for development artifacts.
@@ -80,7 +81,7 @@ Patch coverage remains useful, but PR Test Guard should also surface signals tha
 
 ### Advisory by default
 
-Heuristic signals default to warnings. Repositories can choose later which high-confidence policies deserve to block merges.
+Heuristic signals default to warnings. Repositories can choose which high-confidence policies deserve to block merges.
 
 ### CLI core, integrations on top
 
@@ -113,17 +114,27 @@ Priority cases:
 - test deletion/skip changes with explicit intent;
 - changed code with good coverage but a surviving targeted probe.
 
-## Next: Output and Policy Controls
+## Current Main: Output and Policy Controls
+
+The CLI now separates detection from policy. Default runs remain advisory, while
+repositories can configure selected rules as `off`, `warn`, or `error`.
+Configured error rules exit `1` and emit GitHub error annotations after the
+summary is written.
+
+GitHub summaries group findings by rule, include evidence in tables, and show a
+bounded list of related-test candidates. This makes early adoption practical
+without claiming that every heuristic warning should block merges.
+
+Keep policy separate from detection: the checker identifies signals; the repository decides what blocks a merge.
+
+## Next: Adoption Controls
 
 After dogfooding stabilizes the signals, consider:
 
-- configurable rule enable/disable settings;
-- optional fail-on selected rules or severity;
-- richer GitHub annotations;
 - JSON artifact upload examples;
-- repository path/test mapping configuration.
-
-Keep policy separate from detection: the checker identifies signals; the repository decides what blocks a merge.
+- repository path/test mapping configuration beyond ignored finding paths;
+- per-rule thresholds for high-volume findings;
+- richer GitHub annotations with stable grouping keys.
 
 ## Later: Broader Coverage and Language Support
 

--- a/pr_test_guard/check.py
+++ b/pr_test_guard/check.py
@@ -56,6 +56,7 @@ class AnalysisResult:
     notes: list[str]
     probe_summary: dict[str, Any]
     related_tests: list["RelatedTestCandidate"]
+    policy: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -73,6 +74,7 @@ class AnalysisResult:
             "notes": self.notes,
             "probes": self.probe_summary,
             "related_tests": [item.to_dict() for item in self.related_tests],
+            "policy": self.policy,
         }
 
 

--- a/pr_test_guard/cli.py
+++ b/pr_test_guard/cli.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 
 from .check import CheckError, analyze_repository, default_base
+from .config import GuardConfig, config_from_overrides, load_config
+from .policy import apply_config, exit_code_for
 from .reporters import emit_github, render_json, render_text
 from .version import __version__
 
@@ -59,6 +61,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--coverage",
         default=None,
         help="optional coverage.py XML report used for changed-line coverage checks",
+    )
+    check.add_argument(
+        "--config",
+        default=None,
+        help="optional path to .pr-test-guard.yml, .json, or .toml config",
+    )
+    check.add_argument(
+        "--no-config",
+        action="store_true",
+        help="disable automatic .pr-test-guard.* config discovery",
+    )
+    check.add_argument(
+        "--fail-on",
+        default=None,
+        help="comma-separated rule ids that should fail the command when triggered",
     )
     check.add_argument(
         "--deep",
@@ -136,6 +153,10 @@ def build_parser() -> argparse.ArgumentParser:
 def run_check(parsed: argparse.Namespace) -> int:
     base = parsed.base or default_base()
     try:
+        if parsed.no_config and parsed.config:
+            raise CheckError("--config and --no-config cannot be used together")
+        config = GuardConfig() if parsed.no_config else load_config(Path.cwd(), explicit_path=parsed.config)
+        config = config_from_overrides(config, fail_on=parsed.fail_on)
         result = analyze_repository(
             Path.cwd(),
             base=base,
@@ -144,6 +165,7 @@ def run_check(parsed: argparse.Namespace) -> int:
             test_command=parsed.test_command,
             max_probes=parsed.max_probes,
         )
+        result = apply_config(result, config)
     except CheckError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
@@ -155,8 +177,7 @@ def run_check(parsed: argparse.Namespace) -> int:
     else:
         sys.stdout.write(render_text(result))
 
-    # Findings are advisory by default. A successful analysis exits 0 even when warnings exist.
-    return 0
+    return exit_code_for(result)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/pr_test_guard/config.py
+++ b/pr_test_guard/config.py
@@ -1,0 +1,198 @@
+"""Configuration loading for PR Test Guard."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .check import CheckError
+
+
+RULE_IDS = ("PTG001", "PTG002", "PTG003", "PTG004", "PTG005", "PTG006")
+RULE_ACTIONS = ("off", "warn", "error")
+DEFAULT_CONFIG_NAMES = (
+    ".pr-test-guard.yml",
+    ".pr-test-guard.yaml",
+    ".pr-test-guard.json",
+    ".pr-test-guard.toml",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardConfig:
+    source: str | None = None
+    rule_actions: dict[str, str] = field(default_factory=dict)
+    fail_on: tuple[str, ...] = ()
+    ignore_paths: tuple[str, ...] = ()
+    related_test_max_candidates: int = 5
+
+    def action_for(self, rule_id: str) -> str:
+        action = self.rule_actions.get(rule_id, "warn")
+        if action != "off" and rule_id in self.fail_on:
+            return "error"
+        return action
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "rules": {rule_id: self.action_for(rule_id) for rule_id in RULE_IDS},
+            "policy": {"fail_on": list(self.fail_on)},
+            "paths": {"ignore": list(self.ignore_paths)},
+            "related_tests": {"max_candidates": self.related_test_max_candidates},
+        }
+
+
+def load_config(repo_root: Path, explicit_path: str | None = None) -> GuardConfig:
+    path = _resolve_config_path(repo_root, explicit_path)
+    if path is None:
+        return GuardConfig()
+
+    try:
+        raw = _read_config_file(path)
+    except OSError as exc:
+        raise CheckError(f"unable to read config file {path}: {exc}") from exc
+    except (ValueError, yaml.YAMLError) as exc:
+        raise CheckError(f"unable to parse config file {path}: {exc}") from exc
+    return parse_config(raw, source=str(path))
+
+
+def config_from_overrides(config: GuardConfig, *, fail_on: str | None = None) -> GuardConfig:
+    if not fail_on:
+        return config
+    values = _parse_rule_list(fail_on, field_name="--fail-on")
+    merged = tuple(sorted(set(config.fail_on).union(values)))
+    return GuardConfig(
+        source=config.source,
+        rule_actions=dict(config.rule_actions),
+        fail_on=merged,
+        ignore_paths=config.ignore_paths,
+        related_test_max_candidates=config.related_test_max_candidates,
+    )
+
+
+def parse_config(raw: Any, *, source: str | None = None) -> GuardConfig:
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise CheckError(f"config {source or '<memory>'} must contain a mapping")
+
+    rules = raw.get("rules", {})
+    if rules is None:
+        rules = {}
+    if not isinstance(rules, dict):
+        raise CheckError("config field 'rules' must be a mapping")
+
+    rule_actions: dict[str, str] = {}
+    for rule_id, value in rules.items():
+        normalized_rule = _normalize_rule_id(str(rule_id), field_name="rules")
+        action = _normalize_rule_action(value, field_name=f"rules.{normalized_rule}")
+        rule_actions[normalized_rule] = action
+
+    policy = raw.get("policy", {})
+    if policy is None:
+        policy = {}
+    if not isinstance(policy, dict):
+        raise CheckError("config field 'policy' must be a mapping")
+    fail_on = _parse_rule_list(policy.get("fail_on", ()), field_name="policy.fail_on")
+
+    paths = raw.get("paths", {})
+    if paths is None:
+        paths = {}
+    if not isinstance(paths, dict):
+        raise CheckError("config field 'paths' must be a mapping")
+    ignore_paths = _parse_string_list(paths.get("ignore", ()), field_name="paths.ignore")
+
+    related_tests = raw.get("related_tests", {})
+    if related_tests is None:
+        related_tests = {}
+    if not isinstance(related_tests, dict):
+        raise CheckError("config field 'related_tests' must be a mapping")
+    max_candidates = related_tests.get("max_candidates", 5)
+    if not isinstance(max_candidates, int) or max_candidates < 0:
+        raise CheckError("config field 'related_tests.max_candidates' must be a non-negative integer")
+
+    return GuardConfig(
+        source=source,
+        rule_actions=rule_actions,
+        fail_on=tuple(sorted(set(fail_on))),
+        ignore_paths=tuple(ignore_paths),
+        related_test_max_candidates=max_candidates,
+    )
+
+
+def _resolve_config_path(repo_root: Path, explicit_path: str | None) -> Path | None:
+    if explicit_path:
+        path = Path(explicit_path)
+        return path if path.is_absolute() else repo_root / path
+    for name in DEFAULT_CONFIG_NAMES:
+        path = repo_root / name
+        if path.is_file():
+            return path
+    return None
+
+
+def _read_config_file(path: Path) -> Any:
+    suffix = path.suffix.lower()
+    text = path.read_text(encoding="utf-8")
+    if suffix in {".yml", ".yaml"}:
+        return yaml.safe_load(text)
+    if suffix == ".json":
+        return json.loads(text)
+    if suffix == ".toml":
+        return tomllib.loads(text)
+    raise CheckError(f"unsupported config file extension: {path.suffix}")
+
+
+def _normalize_rule_id(value: str, *, field_name: str) -> str:
+    rule_id = value.strip().upper()
+    if rule_id not in RULE_IDS:
+        raise CheckError(f"{field_name} contains unknown rule id: {value}")
+    return rule_id
+
+
+def _normalize_rule_action(value: Any, *, field_name: str) -> str:
+    if isinstance(value, dict):
+        value = value.get("level", value.get("action"))
+    if isinstance(value, bool):
+        return "warn" if value else "off"
+    if not isinstance(value, str):
+        raise CheckError(f"{field_name} must be one of: {', '.join(RULE_ACTIONS)}")
+    action = value.strip().lower()
+    if action not in RULE_ACTIONS:
+        raise CheckError(f"{field_name} must be one of: {', '.join(RULE_ACTIONS)}")
+    return action
+
+
+def _parse_rule_list(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        items = [item.strip() for item in value.split(",") if item.strip()]
+    elif isinstance(value, list):
+        items = value
+    elif isinstance(value, tuple):
+        items = list(value)
+    else:
+        raise CheckError(f"{field_name} must be a list or comma-separated string")
+    return tuple(_normalize_rule_id(str(item), field_name=field_name) for item in items)
+
+
+def _parse_string_list(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, list):
+        values = value
+    elif isinstance(value, tuple):
+        values = list(value)
+    else:
+        raise CheckError(f"{field_name} must be a string or list of strings")
+    if not all(isinstance(item, str) for item in values):
+        raise CheckError(f"{field_name} must contain only strings")
+    return tuple(item for item in values if item)

--- a/pr_test_guard/policy.py
+++ b/pr_test_guard/policy.py
@@ -1,0 +1,57 @@
+"""Policy application for PR Test Guard findings."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from fnmatch import fnmatch
+
+from .check import AnalysisResult
+from .config import GuardConfig
+from .finding import Finding
+
+
+def apply_config(result: AnalysisResult, config: GuardConfig) -> AnalysisResult:
+    findings: list[Finding] = []
+    suppressed_off: dict[str, int] = {}
+    suppressed_paths = 0
+
+    for finding in result.findings:
+        if _ignored_path(finding.file, config.ignore_paths):
+            suppressed_paths += 1
+            continue
+
+        action = config.action_for(finding.rule_id)
+        if action == "off":
+            suppressed_off[finding.rule_id] = suppressed_off.get(finding.rule_id, 0) + 1
+            continue
+
+        severity = "error" if action == "error" else "warning"
+        findings.append(replace(finding, severity=severity))
+
+    notes = list(result.notes)
+    if suppressed_paths:
+        notes.append(f"Policy: suppressed {suppressed_paths} finding(s) matching paths.ignore.")
+    for rule_id, count in sorted(suppressed_off.items()):
+        notes.append(f"Policy: suppressed {count} {rule_id} finding(s) because the rule is off.")
+
+    error_rules = sorted({item.rule_id for item in findings if item.severity == "error"})
+    if error_rules:
+        notes.append(f"Policy: error rule(s) triggered: {', '.join(error_rules)}.")
+
+    return replace(
+        result,
+        findings=findings,
+        notes=notes,
+        policy=config.to_dict(),
+    )
+
+
+def exit_code_for(result: AnalysisResult) -> int:
+    return 1 if any(item.severity == "error" for item in result.findings) else 0
+
+
+def _ignored_path(path: str | None, patterns: tuple[str, ...]) -> bool:
+    if not path:
+        return False
+    normalized = path.replace("\\", "/")
+    return any(fnmatch(normalized, pattern) for pattern in patterns)

--- a/pr_test_guard/reporters.py
+++ b/pr_test_guard/reporters.py
@@ -27,19 +27,35 @@ def render_text(result: AnalysisResult) -> str:
         f"Base: {result.base}",
         f"Changed files: {len(result.files)} ({production} Python production, {tests} test)",
         f"Related test candidates: {len(result.related_tests)}",
+        f"Policy: {_policy_label(result)}",
         "",
     ]
     if result.findings:
         lines.append(f"{len(result.findings)} review signal(s)")
         lines.append("")
-        for item in result.findings:
-            lines.append(f"⚠ {item.rule_id} {_location(item)}")
-            lines.append(f"  {item.message}")
-            if item.evidence:
-                lines.append(f"  Evidence: {item.evidence}")
+        for rule_id, items in _findings_by_rule(result.findings):
+            lines.append(f"{rule_id} ({_severity_counts(items)})")
+            for item in items:
+                marker = "ERROR" if item.severity == "error" else "WARN"
+                lines.append(f"  [{marker}] {_location(item)}")
+                lines.append(f"  {item.message}")
+                if item.evidence:
+                    lines.append(f"  Evidence: {item.evidence}")
             lines.append("")
     else:
         lines.extend(["No review signals found by the enabled rules.", ""])
+
+    related_limit = _related_test_limit(result)
+    if result.related_tests and related_limit:
+        lines.append("Related Tests")
+        for item in result.related_tests[:related_limit]:
+            symbols = ", ".join(item.matched_symbols[:3])
+            reasons = ", ".join(item.reasons)
+            lines.append(f"- {item.file}:{item.line} {item.test_name} ({symbols}; {reasons})")
+        hidden = len(result.related_tests) - related_limit
+        if hidden > 0:
+            lines.append(f"- ... {hidden} more related test candidate(s) hidden by related_tests.max_candidates")
+        lines.append("")
 
     if result.notes:
         lines.append("Notes")
@@ -69,7 +85,8 @@ def _annotation(item: Finding) -> str:
     message = f"[{item.rule_id}] {item.message}"
     if item.evidence:
         message += f" Evidence: {item.evidence}"
-    return f"::warning{metadata}::{_escape_workflow_value(message)}"
+    command = "error" if item.severity == "error" else "warning"
+    return f"::{command}{metadata}::{_escape_workflow_value(message)}"
 
 
 def github_summary(result: AnalysisResult) -> str:
@@ -78,28 +95,58 @@ def github_summary(result: AnalysisResult) -> str:
         "",
         f"**{len(result.findings)} review signal(s)** found between `{result.base}` and `HEAD`.",
         f"**{len(result.related_tests)} related test candidate(s)** identified from deterministic import/call/name context.",
+        f"**Policy:** {_policy_label(result)}.",
         "",
     ]
     if result.findings:
-        lines.extend(["| Rule | Location | Signal |", "| --- | --- | --- |"])
-        for item in result.findings:
-            lines.append(f"| `{item.rule_id}` | `{_location(item)}` | {item.message} |")
-        lines.append("")
+        for rule_id, items in _findings_by_rule(result.findings):
+            lines.append(f"### {rule_id} ({_severity_counts(items)})")
+            lines.append("")
+            lines.extend(["| Severity | Location | Signal | Evidence |", "| --- | --- | --- | --- |"])
+            for item in items:
+                lines.append(
+                    "| "
+                    f"{_markdown_cell(item.severity)} | "
+                    f"`{_location(item)}` | "
+                    f"{_markdown_cell(item.message)} | "
+                    f"{_markdown_cell(item.evidence or '')} |"
+                )
+            lines.append("")
     else:
         lines.extend(["No review signals found by the enabled rules.", ""])
+    related_limit = _related_test_limit(result)
+    if result.related_tests and related_limit:
+        lines.append("### Related Test Candidates")
+        lines.append("")
+        lines.extend(["| Test | Changed symbol(s) | Reason(s) |", "| --- | --- | --- |"])
+        for item in result.related_tests[:related_limit]:
+            lines.append(
+                "| "
+                f"`{item.file}:{item.line} {item.test_name}` | "
+                f"{_markdown_cell(', '.join(item.matched_symbols))} | "
+                f"{_markdown_cell(', '.join(item.reasons))} |"
+            )
+        hidden = len(result.related_tests) - related_limit
+        if hidden > 0:
+            lines.append(f"| _{hidden} more hidden by `related_tests.max_candidates`_ |  |  |")
+        lines.append("")
     if result.notes:
         lines.append("### Notes")
         lines.append("")
         for note in result.notes:
             lines.append(f"- {note}")
         lines.append("")
-    lines.append("_Advisory by default: findings do not fail the job unless a repository adds its own enforcement policy._")
+    if any(item.severity == "error" for item in result.findings):
+        lines.append("_Configured policy failed because at least one error-level rule triggered._")
+    else:
+        lines.append("_No error-level policy triggered. Warning findings remain advisory._")
     return "\n".join(lines) + "\n"
 
 
 def emit_github(result: AnalysisResult) -> str:
     output_lines = [_annotation(item) for item in result.findings]
-    output_lines.append(f"PR Test Guard: {len(result.findings)} review signal(s); advisory result.")
+    status = "failed policy" if any(item.severity == "error" for item in result.findings) else "advisory result"
+    output_lines.append(f"PR Test Guard: {len(result.findings)} review signal(s); {status}.")
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
         Path(summary_path).open("a", encoding="utf-8").write(github_summary(result))
@@ -111,3 +158,44 @@ def _is_test_path_for_report(path: str) -> bool:
     parts = normalized.split("/")
     filename = parts[-1]
     return "tests" in parts or "test" in parts[:-1] or filename.startswith("test_") or filename.endswith("_test.py")
+
+
+def _findings_by_rule(findings: list[Finding]) -> list[tuple[str, list[Finding]]]:
+    grouped: dict[str, list[Finding]] = {}
+    for item in findings:
+        grouped.setdefault(item.rule_id, []).append(item)
+    return [(rule_id, grouped[rule_id]) for rule_id in sorted(grouped)]
+
+
+def _severity_counts(findings: list[Finding]) -> str:
+    errors = sum(1 for item in findings if item.severity == "error")
+    warnings = len(findings) - errors
+    parts = []
+    if errors:
+        parts.append(f"{errors} error")
+    if warnings:
+        parts.append(f"{warnings} warning")
+    return ", ".join(parts) if parts else "0 findings"
+
+
+def _policy_label(result: AnalysisResult) -> str:
+    if not result.policy or not result.policy.get("source"):
+        fail_on = result.policy.get("policy", {}).get("fail_on", []) if result.policy else []
+        if fail_on:
+            return "command-line override"
+        return "default advisory"
+    return f"loaded from {result.policy['source']}"
+
+
+def _related_test_limit(result: AnalysisResult) -> int:
+    if not result.policy:
+        return 5
+    related_tests = result.policy.get("related_tests")
+    if not isinstance(related_tests, dict):
+        return 5
+    value = related_tests.get("max_candidates", 5)
+    return value if isinstance(value, int) and value >= 0 else 5
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", "<br>")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ license = { file = "LICENSE" }
 authors = [
   { name = "Tigerless Labs" }
 ]
-dependencies = []
+dependencies = [
+  "PyYAML>=6.0"
+]
 
 [project.optional-dependencies]
 dev = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 coverage
 pytest
+PyYAML>=6.0

--- a/tests/test_config_policy.py
+++ b/tests/test_config_policy.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from pr_test_guard.cli import main
+
+
+def run(*args: str, cwd: Path) -> None:
+    subprocess.run(list(args), cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run("git", "init", "-b", "main", cwd=repo)
+    run("git", "config", "user.name", "Test User", cwd=repo)
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    return repo
+
+
+def commit_all(repo: Path, message: str) -> None:
+    run("git", "add", "-A", cwd=repo)
+    run("git", "commit", "-m", message, cwd=repo)
+
+
+def make_weak_mock_repo(tmp_path: Path) -> Path:
+    repo = make_repo(tmp_path)
+    write(repo / "payment.py", "def charge(amount):\n    return amount > 0\n")
+    write(repo / "tests/test_payment.py", "from payment import charge\n\ndef test_charge():\n    assert charge(1) is True\n")
+    commit_all(repo, "base")
+
+    write(repo / "payment.py", "def charge(amount):\n    return amount >= 0\n")
+    write(
+        repo / "tests/test_payment.py",
+        "from unittest.mock import patch\nfrom payment import charge\n\n"
+        "@patch('payment.charge')\n"
+        "def test_charge(mock_charge):\n"
+        "    mock_charge.return_value = True\n"
+        "    result = charge(0)\n"
+        "    assert result is not None\n",
+    )
+    commit_all(repo, "change behavior and test")
+    return repo
+
+
+def test_config_can_disable_rules_and_promote_error_policy(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo = make_weak_mock_repo(tmp_path)
+    write(
+        repo / ".pr-test-guard.yml",
+        "rules:\n"
+        "  PTG003: off\n"
+        "  PTG005: error\n"
+        "related_tests:\n"
+        "  max_candidates: 1\n",
+    )
+    monkeypatch.chdir(repo)
+
+    code = main(["check", "--base", "HEAD~1", "--format", "json"])
+
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["rule_id"] for item in payload["findings"]] == ["PTG005"]
+    assert payload["findings"][0]["severity"] == "error"
+    assert payload["policy"]["rules"]["PTG003"] == "off"
+    assert payload["policy"]["rules"]["PTG005"] == "error"
+    assert any("suppressed 1 PTG003" in note for note in payload["notes"])
+    assert any("error rule(s) triggered: PTG005" in note for note in payload["notes"])
+
+
+def test_no_config_keeps_default_advisory_behavior(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    write(repo / "tests/test_app.py", "from app import value\n\ndef test_value():\n    assert value() == 1\n")
+    commit_all(repo, "base")
+
+    write(repo / "app.py", "def value():\n    return 2\n")
+    commit_all(repo, "change production only")
+    write(repo / ".pr-test-guard.yml", "rules:\n  PTG001: error\n")
+    monkeypatch.chdir(repo)
+
+    code = main(["check", "--base", "HEAD~1", "--format", "json", "--no-config"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["findings"][0]["rule_id"] == "PTG001"
+    assert payload["findings"][0]["severity"] == "warning"
+    assert payload["policy"]["source"] is None
+
+
+def test_github_output_uses_error_annotations_and_grouped_summary(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo = make_weak_mock_repo(tmp_path)
+    summary = tmp_path / "summary.md"
+    write(repo / ".pr-test-guard.yml", "policy:\n  fail_on: [PTG005]\n")
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    code = main(["check", "--base", "HEAD~1", "--format", "github"])
+
+    assert code == 1
+    output = capsys.readouterr().out
+    assert "::error file=tests/test_payment.py,line=4::[PTG005]" in output
+    rendered_summary = summary.read_text(encoding="utf-8")
+    assert "### PTG003 (1 warning)" in rendered_summary
+    assert "### PTG005 (1 error)" in rendered_summary
+    assert "### Related Test Candidates" in rendered_summary
+    assert "Configured policy failed" in rendered_summary
+
+
+def test_paths_ignore_suppresses_matching_findings(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_weak_mock_repo(tmp_path)
+    write(repo / ".pr-test-guard.yml", "paths:\n  ignore:\n    - tests/**\n")
+    monkeypatch.chdir(repo)
+
+    code = main(["check", "--base", "HEAD~1", "--format", "json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["findings"] == []
+    assert any("matching paths.ignore" in note for note in payload["notes"])
+
+
+def test_invalid_config_returns_operational_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    commit_all(repo, "base")
+    write(repo / "app.py", "def value():\n    return 2\n")
+    commit_all(repo, "change")
+    write(repo / ".pr-test-guard.yml", "rules:\n  PTG999: warn\n")
+    monkeypatch.chdir(repo)
+
+    code = main(["check", "--base", "HEAD~1"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "unknown rule id" in captured.err
+
+
+def test_config_and_no_config_are_mutually_exclusive(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    commit_all(repo, "base")
+    monkeypatch.chdir(repo)
+
+    code = main(["check", "--base", "HEAD", "--config", ".pr-test-guard.yml", "--no-config"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "--config and --no-config" in captured.err


### PR DESCRIPTION
## Summary

- add .pr-test-guard.* config loading for rule off/warn/error policy, ignored finding paths, related-test display limits, and --fail-on overrides
- apply policy after detection so default runs remain advisory while selected rules can fail CI
- improve text/GitHub output with rule grouping, evidence tables, related-test candidates, and error annotations
- document CLI/Action config usage and add policy regression tests

## Validation

- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- git diff --check