### PR TITLE
release: prepare v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">PR Test Guard</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.3-brightgreen.svg" alt="release v0.2.3" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/release-v0.2.4-brightgreen.svg" alt="release v0.2.4" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **Lightweight, rule-based test-quality checks for pull requests.**
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Current main adds configurable rule policy and richer GitHub output on top of the `0.2.3` related-test context release.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.4` adds configurable rule policy and richer GitHub output on top of the related-test context release.
 
 | | |
 | --- | --- |
@@ -94,7 +94,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tigerless-labs/pr-test-guard@v0.2.3
+      - uses: tigerless-labs/pr-test-guard@v0.2.4
         with:
           base: origin/${{ github.base_ref }}
           config: .pr-test-guard.yml
@@ -103,7 +103,7 @@ jobs:
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.2.3
+      - uses: tigerless-labs/pr-test-guard@v0.2.4
         with:
           base: origin/${{ github.base_ref }}
           coverage: coverage.xml
@@ -255,11 +255,11 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
-- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.3` release.
+- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.4` release.
 
 ## Current Scope
 
-Current main supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Version `0.2.4` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -110,6 +110,6 @@ CI integration should be advisory by default. Repositories can opt into stricter
 
 ## Current Limits
 
-Current main provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
+Version `0.2.4` provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -92,7 +92,7 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
   with:
     fetch-depth: 0
 
-- uses: tigerless-labs/pr-test-guard@v0.2.3
+- uses: tigerless-labs/pr-test-guard@v0.2.4
   with:
     base: origin/${{ github.base_ref }}
 ```
@@ -102,7 +102,7 @@ The Action emits GitHub warning annotations and appends a job summary. Findings 
 To use repository policy:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.3
+- uses: tigerless-labs/pr-test-guard@v0.2.4
   with:
     base: origin/${{ github.base_ref }}
     config: .pr-test-guard.yml
@@ -111,7 +111,7 @@ To use repository policy:
 To enforce a high-confidence rule without a config file:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.3
+- uses: tigerless-labs/pr-test-guard@v0.2.4
   with:
     base: origin/${{ github.base_ref }}
     fail-on: PTG006

--- a/docs/releases/v0.2.4.md
+++ b/docs/releases/v0.2.4.md
@@ -1,0 +1,27 @@
+# PR Test Guard v0.2.4
+
+Version `0.2.4` is a patch release focused on configurable adoption policy and more usable GitHub Actions output.
+
+## What Changed
+
+- Added `.pr-test-guard.yml`, `.pr-test-guard.yaml`, `.pr-test-guard.json`, and `.pr-test-guard.toml` config discovery for the direct checker.
+- Added rule-level `off`, `warn`, and `error` policy so repositories can suppress noisy rules or promote selected rules to CI failures.
+- Added `policy.fail_on`, CLI `--fail-on`, and GitHub Action `fail-on` support for one-off enforcement of selected rule ids.
+- Added `paths.ignore` to suppress findings on configured path globs and `related_tests.max_candidates` to keep related-test output bounded.
+- Improved text and GitHub output with rule grouping, severity counts, evidence tables, related-test candidate summaries, and GitHub error annotations for error-level findings.
+- Added GitHub Action `config` input and expanded documentation for advisory and enforcing rollout modes.
+
+## Compatibility
+
+- Default behavior remains advisory: without config or `--fail-on`, findings still exit `0`.
+- Operational errors still exit `2`; configured error-level findings exit `1`.
+- Existing CLI and Action inputs remain compatible.
+- Configuration is applied after detection. It controls visibility and CI policy, not rule certainty.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest tests
+.venv/bin/python -m pr_test_guard validate-cases --run
+git diff --check
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Current main keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
+Version `0.2.4` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
 
-## What Exists on Main
+## What Exists in 0.2.4
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
@@ -22,7 +22,7 @@ Current main keeps the first public-ready shape from `0.1.0`, adds deterministic
 
 The fixture runner is development infrastructure for the tool. It is not the product's public benchmark identity.
 
-## Current Main: PTG005 Semantic Lite
+## Current: PTG005 Semantic Lite
 
 The PTG005 precision work remains deterministic and offline, with three bounded layers.
 
@@ -53,7 +53,7 @@ The PTG005 precision work remains deterministic and offline, with three bounded 
 
 This layer improves **structural and test-semantics precision**, not business-intent understanding. It still does not decide whether a mock is appropriate, build a repository-wide call graph, or infer dynamic Python types. PTG005 remains advisory. Real-PR dogfooding should measure whether the relationship layer removes low-value warnings while retaining direct changed-symbol and unconstrained changed-internal-dependency cases.
 
-## Current Main: Related Test Context
+## Current: Related Test Context
 
 The direct checker records candidate tests tied to changed symbols through exact
 imports, direct calls, supported mock targets, and test-name tokens when another
@@ -114,7 +114,7 @@ Priority cases:
 - test deletion/skip changes with explicit intent;
 - changed code with good coverage but a surviving targeted probe.
 
-## Current Main: Output and Policy Controls
+## Current: Output and Policy Controls
 
 The CLI now separates detection from policy. Default runs remain advisory, while
 repositories can configure selected rules as `off`, `warn`, or `error`.

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -94,7 +94,7 @@ Human-readable report for the fixture. Findings are review signals and do not ce
 
 ## Stability
 
-Version `0.2.3` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
+Version `0.2.4` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
 
 Changes should preserve two properties:
 

--- a/pr_test_guard/version.py
+++ b/pr_test_guard/version.py
@@ -1,3 +1,3 @@
 """Project version."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-test-guard"
-version = "0.2.3"
+version = "0.2.4"
 description = "Lightweight, rule-based test-quality checks for pull requests."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ import pr_test_guard
 
 
 def test_package_version_is_current() -> None:
-    assert pr_test_guard.__version__ == "0.2.3"
+    assert pr_test_guard.__version__ == "0.2.4"


### PR DESCRIPTION
## Summary

- bump package version to 0.2.4
- add v0.2.4 release notes for configurable policy and GitHub output
- update README, roadmap, methodology, real PR input docs, runner artifact stability note, and Action examples to reference v0.2.4

## Validation

- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- git diff --check