### PR TITLE
feat: write check JSON artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ If the project already produces a `coverage.py` XML report, add it as another si
 pr-test-guard check --base origin/main --coverage coverage.xml
 ```
 
+To keep a structured report for CI artifacts or later analysis, write JSON in
+addition to the selected human-facing output:
+
+```bash
+pr-test-guard check \
+  --base origin/main \
+  --format text \
+  --json-output pr-test-guard-report.json
+```
+
 For the optional deeper check, explicitly provide the project's test command. PR Test Guard creates an isolated Git worktree, runs the unmodified tests once, then applies at most a few bounded probes to changed Python lines:
 
 ```bash
@@ -111,6 +121,17 @@ Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflo
           test-command: pytest -q
           max-probes: "3"
           fail-on: PTG006
+```
+
+Current main can also write and optionally upload a structured JSON report:
+
+```yaml
+      - uses: tigerless-labs/pr-test-guard@main
+        with:
+          base: origin/${{ github.base_ref }}
+          json-output: pr-test-guard-report.json
+          upload-artifact: "true"
+          artifact-name: pr-test-guard-report
 ```
 
 The existing regression-fixture commands remain available for development of PR Test Guard itself. Install the development extras first:
@@ -196,11 +217,12 @@ current Git repository + base ref + optional coverage/test command
   -> pr-test-guard check
   -> PR-scoped rule signals
   -> text / JSON / GitHub Actions output
+  -> optional JSON report artifact
 ```
 
 The older normalized bundle under `examples/real-pr-bundles/` remains as a development fixture and compatibility prototype for richer CI artifacts. It can include PR metadata, a diff, CI/test results, coverage, and optional change-intent context, but it is not required by the direct checker. See [Real PR Input](docs/real-pr-input.md).
 
-The reusable `action.yml` calls the same CLI/core. There is no separate hosted analysis service and no API key is required for the default path. GitHub output is grouped by rule, includes related-test candidates up to the configured limit, and emits error annotations for rules configured as error-level policy.
+The reusable `action.yml` calls the same CLI/core. There is no separate hosted analysis service and no API key is required for the default path. GitHub output is grouped by rule, includes related-test candidates up to the configured limit, emits error annotations for rules configured as error-level policy, and can retain the full JSON report as a workflow artifact.
 
 ## Mock and Probe Boundaries
 
@@ -269,6 +291,7 @@ Version `0.2.4` supports direct Python/pytest PR analysis from the current Git r
 - lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites, with constrained dependency mocks suppressed from PTG005 warnings;
 - optional bounded targeted probes that survive an explicit test command.
 - configurable rule policy through `.pr-test-guard.yml`, `--config`, `--no-config`, and `--fail-on`.
+- optional JSON report output through `--json-output` and GitHub artifact upload on current main.
 
 It still does **not** include:
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,18 @@ inputs:
     description: Comma-separated rule ids that should fail the Action when triggered.
     required: false
     default: ""
+  json-output:
+    description: Path where the Action writes the full JSON report.
+    required: false
+    default: pr-test-guard-report.json
+  upload-artifact:
+    description: Upload the JSON report as a GitHub Actions artifact.
+    required: false
+    default: "false"
+  artifact-name:
+    description: Name for the uploaded JSON report artifact.
+    required: false
+    default: pr-test-guard-report
   deep:
     description: Enable bounded targeted probes. Requires test-command.
     required: false
@@ -74,11 +86,13 @@ runs:
         echo "base=$base" >> "$GITHUB_OUTPUT"
 
     - name: Run PR Test Guard
+      id: check
       shell: bash
       env:
         INPUT_COVERAGE: ${{ inputs.coverage }}
         INPUT_CONFIG: ${{ inputs.config }}
         INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_JSON_OUTPUT: ${{ inputs.json-output }}
         INPUT_DEEP: ${{ inputs.deep }}
         INPUT_TEST_COMMAND: ${{ inputs.test-command }}
         INPUT_MAX_PROBES: ${{ inputs.max-probes }}
@@ -99,6 +113,10 @@ runs:
           args+=(--fail-on "$INPUT_FAIL_ON")
         fi
 
+        if [[ -n "$INPUT_JSON_OUTPUT" ]]; then
+          args+=(--json-output "$INPUT_JSON_OUTPUT")
+        fi
+
         if [[ "$INPUT_DEEP" == "true" ]]; then
           if [[ -z "$INPUT_TEST_COMMAND" ]]; then
             echo "deep=true requires test-command." >&2
@@ -107,4 +125,22 @@ runs:
           args+=(--deep --test-command "$INPUT_TEST_COMMAND" --max-probes "$INPUT_MAX_PROBES")
         fi
 
+        set +e
         pr-test-guard "${args[@]}"
+        status=$?
+        set -e
+        echo "exit-code=$status" >> "$GITHUB_OUTPUT"
+
+    - name: Upload PR Test Guard JSON report
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.json-output }}
+        if-no-files-found: warn
+
+    - name: Complete PR Test Guard
+      shell: bash
+      env:
+        EXIT_CODE: ${{ steps.check.outputs.exit-code }}
+      run: exit "${EXIT_CODE:-0}"

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -26,6 +26,16 @@ pr-test-guard check \
   --max-probes 3
 ```
 
+`--json-output` writes the complete structured result in addition to the selected
+stdout format. Parent directories are created automatically:
+
+```bash
+pr-test-guard check \
+  --base origin/main \
+  --format github \
+  --json-output artifacts/pr-test-guard-report.json
+```
+
 The default path does not require a PR body, issue text, LLM output, or a custom JSON bundle.
 
 ## Configuration
@@ -76,6 +86,7 @@ The current Python/pytest path uses:
 - optional `coverage.py` XML;
 - optional explicit test command for bounded targeted probes.
 - optional `.pr-test-guard.*` policy configuration.
+- optional JSON report output path for CI artifacts or follow-up analysis.
 
 Missing optional artifacts are reported as skipped checks, not silently converted into negative evidence.
 
@@ -119,6 +130,20 @@ To enforce a high-confidence rule without a config file:
 
 Rules configured as `error` emit GitHub error annotations and make the Action fail after the summary is written. Warning rules remain advisory.
 
+Current main also supports JSON report artifacts:
+
+```yaml
+- uses: tigerless-labs/pr-test-guard@main
+  with:
+    base: origin/${{ github.base_ref }}
+    json-output: pr-test-guard-report.json
+    upload-artifact: "true"
+    artifact-name: pr-test-guard-report
+```
+
+The Action records the checker exit code, writes the JSON report, uploads it when
+requested, and only then fails the job for configured error-level findings.
+
 ## Deep Probe Boundary
 
 `--deep` is opt-in because it executes the repository's configured test command. PR Test Guard first creates an isolated Git worktree at `HEAD`, verifies that the unmodified test command passes, and only then applies a bounded number of supported probes.
@@ -147,6 +172,6 @@ This bundle is no longer required for normal real-PR use.
 
 ## Security Boundary
 
-The static/default checker only reads repository content, Git history, and an optional repository-local config file. Coverage is consumed only when explicitly supplied.
+The static/default checker only reads repository content, Git history, and an optional repository-local config file. Coverage is consumed only when explicitly supplied. JSON report output writes only the analysis result that the CLI can already print.
 
 Deep probes execute a test command chosen by the repository/user. In GitHub Actions, that execution therefore follows the trust boundary of the workflow that opted into it. PR Test Guard does not request repository write permission or secrets for its default advisory path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,7 @@ Version `0.2.4` keeps the first public-ready shape from `0.1.0`, adds determinis
 - dogfood-derived sanitized review examples and public-safe distilled PTG005 controls;
 - text, JSON, and GitHub Actions output;
 - `.pr-test-guard.*` configuration for rule `off` / `warn` / `error`, ignored paths, related-test display limits, and one-off `--fail-on` CI policy;
+- optional `--json-output` report writing and GitHub artifact upload on current main;
 - reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
 - normalized real-PR bundle compatibility for development artifacts.
@@ -125,13 +126,15 @@ GitHub summaries group findings by rule, include evidence in tables, and show a
 bounded list of related-test candidates. This makes early adoption practical
 without claiming that every heuristic warning should block merges.
 
+Current main can also write the full JSON result to a configured path and upload
+that report from the GitHub Action before returning a policy failure.
+
 Keep policy separate from detection: the checker identifies signals; the repository decides what blocks a merge.
 
 ## Next: Adoption Controls
 
 After dogfooding stabilizes the signals, consider:
 
-- JSON artifact upload examples;
 - repository path/test mapping configuration beyond ignored finding paths;
 - per-rule thresholds for high-volume findings;
 - richer GitHub annotations with stable grouping keys.

--- a/pr_test_guard/cli.py
+++ b/pr_test_guard/cli.py
@@ -99,6 +99,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="text",
         help="output format (default: text)",
     )
+    check.add_argument(
+        "--json-output",
+        default=None,
+        help="optional path to also write the full JSON analysis result",
+    )
 
     validate_cases = subcommands.add_parser(
         "validate-cases",
@@ -166,6 +171,8 @@ def run_check(parsed: argparse.Namespace) -> int:
             max_probes=parsed.max_probes,
         )
         result = apply_config(result, config)
+        if parsed.json_output:
+            write_json_output(Path(parsed.json_output), render_json(result))
     except CheckError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
@@ -178,6 +185,15 @@ def run_check(parsed: argparse.Namespace) -> int:
         sys.stdout.write(render_text(result))
 
     return exit_code_for(result)
+
+
+def write_json_output(path: Path, content: str) -> None:
+    try:
+        if path.parent != Path("."):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise CheckError(f"unable to write JSON output {path}: {exc}") from exc
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_config_policy.py
+++ b/tests/test_config_policy.py
@@ -4,6 +4,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import yaml
+
 from pr_test_guard.cli import main
 
 
@@ -161,3 +163,78 @@ def test_config_and_no_config_are_mutually_exclusive(tmp_path: Path, monkeypatch
     captured = capsys.readouterr()
     assert code == 2
     assert "--config and --no-config" in captured.err
+
+
+def test_check_can_write_json_output_alongside_text_report(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    write(repo / "tests/test_app.py", "from app import value\n\ndef test_value():\n    assert value() == 1\n")
+    commit_all(repo, "base")
+    write(repo / "app.py", "def value():\n    return 2\n")
+    commit_all(repo, "change production only")
+    monkeypatch.chdir(repo)
+
+    report_path = repo / "artifacts" / "pr-test-guard-report.json"
+    code = main(["check", "--base", "HEAD~1", "--json-output", str(report_path)])
+
+    assert code == 0
+    assert "PR Test Guard" in capsys.readouterr().out
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["findings"] == 1
+    assert payload["findings"][0]["rule_id"] == "PTG001"
+
+
+def test_json_output_matches_policy_filtered_stdout(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_weak_mock_repo(tmp_path)
+    write(repo / ".pr-test-guard.yml", "rules:\n  PTG003: off\npolicy:\n  fail_on: [PTG005]\n")
+    monkeypatch.chdir(repo)
+
+    report_path = repo / "report.json"
+    code = main(["check", "--base", "HEAD~1", "--format", "json", "--json-output", str(report_path)])
+
+    assert code == 1
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert file_payload == stdout_payload
+    assert [item["rule_id"] for item in file_payload["findings"]] == ["PTG005"]
+    assert file_payload["findings"][0]["severity"] == "error"
+
+
+def test_github_format_can_also_write_json_output(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_weak_mock_repo(tmp_path)
+    summary = tmp_path / "summary.md"
+    report_path = repo / "ptg" / "report.json"
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    code = main(["check", "--base", "HEAD~1", "--format", "github", "--json-output", str(report_path)])
+
+    assert code == 0
+    assert "PR Test Guard:" in capsys.readouterr().out
+    assert "## PR Test Guard" in summary.read_text(encoding="utf-8")
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert {item["rule_id"] for item in payload["findings"]} == {"PTG003", "PTG005"}
+
+
+def test_invalid_json_output_path_returns_operational_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo = make_repo(tmp_path)
+    write(repo / "app.py", "def value():\n    return 1\n")
+    commit_all(repo, "base")
+    monkeypatch.chdir(repo)
+
+    code = main(["check", "--base", "HEAD", "--json-output", str(repo)])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "unable to write JSON output" in captured.err
+
+
+def test_action_supports_json_artifact_upload() -> None:
+    action = yaml.safe_load(Path("action.yml").read_text(encoding="utf-8"))
+
+    assert action["inputs"]["json-output"]["default"] == "pr-test-guard-report.json"
+    assert action["inputs"]["upload-artifact"]["default"] == "false"
+    assert action["inputs"]["artifact-name"]["default"] == "pr-test-guard-report"
+    steps = action["runs"]["steps"]
+    assert any(step.get("uses") == "actions/upload-artifact@v4" for step in steps)
+    assert steps[-1]["name"] == "Complete PR Test Guard"


### PR DESCRIPTION
## Summary

- add check --json-output to write the full policy-filtered JSON result alongside text, JSON, or GitHub stdout
- create parent directories for JSON reports and return an operational error when the report cannot be written
- add GitHub Action json-output, upload-artifact, and artifact-name inputs
- preserve the checker exit code so JSON upload can happen before configured policy failures fail the Action
- document CLI and Action artifact usage and update roadmap adoption controls

## Validation

- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- git diff --check