### PR TITLE
release: prepare v0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">PR Test Guard</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.4-brightgreen.svg" alt="release v0.2.4" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/release-v0.2.5-brightgreen.svg" alt="release v0.2.5" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **Lightweight, rule-based test-quality checks for pull requests.**
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.4` adds configurable rule policy and richer GitHub output on top of the related-test context release.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.5` adds JSON report artifact output on top of configurable rule policy and richer GitHub output.
 
 | | |
 | --- | --- |
@@ -104,7 +104,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tigerless-labs/pr-test-guard@v0.2.4
+      - uses: tigerless-labs/pr-test-guard@v0.2.5
         with:
           base: origin/${{ github.base_ref }}
           config: .pr-test-guard.yml
@@ -113,7 +113,7 @@ jobs:
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.2.4
+      - uses: tigerless-labs/pr-test-guard@v0.2.5
         with:
           base: origin/${{ github.base_ref }}
           coverage: coverage.xml
@@ -123,10 +123,10 @@ Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflo
           fail-on: PTG006
 ```
 
-Current main can also write and optionally upload a structured JSON report:
+The Action can also write and optionally upload a structured JSON report:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@main
+      - uses: tigerless-labs/pr-test-guard@v0.2.5
         with:
           base: origin/${{ github.base_ref }}
           json-output: pr-test-guard-report.json
@@ -277,11 +277,11 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
-- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.4` release.
+- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.5` release.
 
 ## Current Scope
 
-Version `0.2.4` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Version `0.2.5` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;
@@ -291,7 +291,7 @@ Version `0.2.4` supports direct Python/pytest PR analysis from the current Git r
 - lightweight symbol-resolved mock relationships around changed Python symbols and changed call sites, with constrained dependency mocks suppressed from PTG005 warnings;
 - optional bounded targeted probes that survive an explicit test command.
 - configurable rule policy through `.pr-test-guard.yml`, `--config`, `--no-config`, and `--fail-on`.
-- optional JSON report output through `--json-output` and GitHub artifact upload on current main.
+- optional JSON report output through `--json-output` and GitHub artifact upload.
 
 It still does **not** include:
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -110,6 +110,6 @@ CI integration should be advisory by default. Repositories can opt into stricter
 
 ## Current Limits
 
-Version `0.2.4` provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
+Version `0.2.5` provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, JSON report artifacts, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -103,7 +103,7 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
   with:
     fetch-depth: 0
 
-- uses: tigerless-labs/pr-test-guard@v0.2.4
+- uses: tigerless-labs/pr-test-guard@v0.2.5
   with:
     base: origin/${{ github.base_ref }}
 ```
@@ -113,7 +113,7 @@ The Action emits GitHub warning annotations and appends a job summary. Findings 
 To use repository policy:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.4
+- uses: tigerless-labs/pr-test-guard@v0.2.5
   with:
     base: origin/${{ github.base_ref }}
     config: .pr-test-guard.yml
@@ -122,7 +122,7 @@ To use repository policy:
 To enforce a high-confidence rule without a config file:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.4
+- uses: tigerless-labs/pr-test-guard@v0.2.5
   with:
     base: origin/${{ github.base_ref }}
     fail-on: PTG006
@@ -130,10 +130,10 @@ To enforce a high-confidence rule without a config file:
 
 Rules configured as `error` emit GitHub error annotations and make the Action fail after the summary is written. Warning rules remain advisory.
 
-Current main also supports JSON report artifacts:
+The Action also supports JSON report artifacts:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@main
+- uses: tigerless-labs/pr-test-guard@v0.2.5
   with:
     base: origin/${{ github.base_ref }}
     json-output: pr-test-guard-report.json

--- a/docs/releases/v0.2.5.md
+++ b/docs/releases/v0.2.5.md
@@ -1,0 +1,27 @@
+# PR Test Guard v0.2.5
+
+Version `0.2.5` is a patch release focused on retaining structured checker output from local and CI runs.
+
+## What Changed
+
+- Added `pr-test-guard check --json-output <path>` to write the full JSON analysis result alongside text, JSON, or GitHub stdout output.
+- Ensured JSON report files contain the final policy-filtered result, including configured severities and suppressed-finding notes.
+- Created parent directories for JSON reports automatically and returned an operational error when a report cannot be written.
+- Added GitHub Action `json-output`, `upload-artifact`, and `artifact-name` inputs.
+- Updated the GitHub Action flow so it records the checker exit code, uploads the JSON report when requested, and only then returns configured policy failures.
+- Documented CLI and Action JSON artifact usage in the README and direct real-PR input guide.
+
+## Compatibility
+
+- Default behavior remains advisory without config or `--fail-on`.
+- Existing CLI and Action inputs remain compatible.
+- JSON artifact upload is opt-in for the Action.
+- Error-level policy findings still fail the Action, but only after the report step has a chance to upload.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest tests
+.venv/bin/python -m pr_test_guard validate-cases --run
+git diff --check
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Version `0.2.4` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
+Version `0.2.5` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, JSON report artifacts, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
 
-## What Exists in 0.2.4
+## What Exists in 0.2.5
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
@@ -16,7 +16,7 @@ Version `0.2.4` keeps the first public-ready shape from `0.1.0`, adds determinis
 - dogfood-derived sanitized review examples and public-safe distilled PTG005 controls;
 - text, JSON, and GitHub Actions output;
 - `.pr-test-guard.*` configuration for rule `off` / `warn` / `error`, ignored paths, related-test display limits, and one-off `--fail-on` CI policy;
-- optional `--json-output` report writing and GitHub artifact upload on current main;
+- optional `--json-output` report writing and GitHub artifact upload;
 - reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
 - normalized real-PR bundle compatibility for development artifacts.
@@ -126,7 +126,7 @@ GitHub summaries group findings by rule, include evidence in tables, and show a
 bounded list of related-test candidates. This makes early adoption practical
 without claiming that every heuristic warning should block merges.
 
-Current main can also write the full JSON result to a configured path and upload
+The checker can also write the full JSON result to a configured path and upload
 that report from the GitHub Action before returning a policy failure.
 
 Keep policy separate from detection: the checker identifies signals; the repository decides what blocks a merge.

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -94,7 +94,7 @@ Human-readable report for the fixture. Findings are review signals and do not ce
 
 ## Stability
 
-Version `0.2.4` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
+Version `0.2.5` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
 
 Changes should preserve two properties:
 

--- a/pr_test_guard/version.py
+++ b/pr_test_guard/version.py
@@ -1,3 +1,3 @@
 """Project version."""
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-test-guard"
-version = "0.2.4"
+version = "0.2.5"
 description = "Lightweight, rule-based test-quality checks for pull requests."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ import pr_test_guard
 
 
 def test_package_version_is_current() -> None:
-    assert pr_test_guard.__version__ == "0.2.4"
+    assert pr_test_guard.__version__ == "0.2.5"


### PR DESCRIPTION
## Summary

- bump package version to 0.2.5
- add v0.2.5 release notes for JSON artifact output
- update README, roadmap, methodology, real PR input docs, runner artifact stability note, and Action examples to reference v0.2.5
- replace current-main JSON artifact wording with stable v0.2.5 usage

## Validation

- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- git diff --check