### PR TITLE
feat: draft dogfood reviews from check reports

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -8,10 +8,11 @@ them for public examples, aggregate counts, or rule-planning discussions.
 ## Workflow
 
 1. Run `pr-test-guard check` on a real PR checkout.
-2. Review each finding as a reviewer would.
-3. Keep any raw notes in a local or private location.
-4. Convert the review into a sanitized record.
-5. Aggregate sanitized records to choose the next fixture or rule change.
+2. Draft a local review record from the JSON report.
+3. Review each finding as a reviewer would.
+4. Keep any raw notes in a local or private location.
+5. Convert the review into a sanitized record.
+6. Aggregate sanitized records to choose the next fixture or rule change.
 
 The sanitized record should preserve the evidence shape that matters for rule
 work while avoiding repository-specific details.
@@ -53,6 +54,30 @@ A practical local layout is:
     repo-001-pr-001.json
 ```
 
+Draft the local raw record from a checker JSON report:
+
+```bash
+pr-test-guard check --base origin/main --json-output /tmp/pr-test-guard-report.json
+python3 scripts/draft_dogfood_review.py \
+  /tmp/pr-test-guard-report.json \
+  --review-id review_001 \
+  --repo-alias repo_001 \
+  --pr-alias pr_001 \
+  --test-framework pytest \
+  --test-command-shape pytest \
+  -o ~/private/pr-test-guard-dogfood/raw/repo-001-pr-001.json
+```
+
+The draft keeps local-only fields such as file, line, message, and evidence so
+the reviewer can label the finding. Before publishing or committing anything,
+convert the raw record into the shareable schema:
+
+```bash
+python3 scripts/sanitize_dogfood_review.py \
+  ~/private/pr-test-guard-dogfood/raw/repo-001-pr-001.json \
+  -o ~/private/pr-test-guard-dogfood/sanitized/repo-001-pr-001.json
+```
+
 The public repository can include sanitized examples under
 `examples/dogfood-reviews/` and scripts that operate on sanitized records. Raw
 notes should stay local or in a private workspace.
@@ -64,6 +89,9 @@ Run:
 ```bash
 python3 scripts/summarize_dogfood_reviews.py ~/private/pr-test-guard-dogfood/sanitized
 ```
+
+The summary reports label counts, label rates, top categories, top evidence
+shapes, action counts, and recommended next actions per rule.
 
 Use the aggregate output to decide whether the next PR should add a regression
 fixture, tighten a rule, improve finding evidence, or only update documentation.

--- a/scripts/draft_dogfood_review.py
+++ b/scripts/draft_dogfood_review.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Create a local dogfood review draft from a PR Test Guard JSON report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VALID_TEST_FRAMEWORKS = {"pytest", "unittest", "mixed", "unknown"}
+VALID_COMMAND_SHAPES = {"pytest", "unittest", "custom", "none", "unknown"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def draft_review(
+    report: dict[str, Any],
+    *,
+    review_id: str,
+    repo_alias: str,
+    pr_alias: str,
+    test_framework: str,
+    test_command_shape: str,
+) -> dict[str, Any]:
+    findings = report.get("findings") if isinstance(report.get("findings"), list) else []
+    notes = report.get("notes") if isinstance(report.get("notes"), list) else []
+    probes = report.get("probes") if isinstance(report.get("probes"), dict) else {}
+
+    return {
+        "schema_version": "1",
+        "review_id": _alias(review_id, "review_001", r"[a-z0-9][a-z0-9_-]*"),
+        "source": {
+            "visibility": "sanitized_private_review",
+            "repo_alias": _alias(repo_alias, "repo_001", r"repo_[0-9]{3,}"),
+            "pr_alias": _alias(pr_alias, "pr_001", r"pr_[0-9]{3,}"),
+        },
+        "environment": {
+            "language": "python" if _looks_like_python_report(report) else "unknown",
+            "test_framework": test_framework if test_framework in VALID_TEST_FRAMEWORKS else "unknown",
+            "coverage_supplied": _coverage_supplied(notes),
+            "deep_enabled": bool(probes.get("enabled")) if isinstance(probes.get("enabled"), bool) else False,
+            "test_command_shape": test_command_shape if test_command_shape in VALID_COMMAND_SHAPES else "unknown",
+        },
+        "report": {
+            "base": report.get("base"),
+            "head": report.get("head"),
+            "summary": report.get("summary") if isinstance(report.get("summary"), dict) else {},
+        },
+        "findings": [_draft_finding(item) for item in findings if isinstance(item, dict)],
+    }
+
+
+def _draft_finding(finding: dict[str, Any]) -> dict[str, Any]:
+    evidence = finding.get("evidence") if isinstance(finding.get("evidence"), str) else ""
+    message = finding.get("message") if isinstance(finding.get("message"), str) else ""
+    return {
+        "rule_id": finding.get("rule_id"),
+        "review_label": "needs_more_context",
+        "category": "uncategorized",
+        "path_kind": _path_kind(finding.get("file")),
+        "symbol_kind": _symbol_kind(evidence, message),
+        "dependency_kind": _dependency_kind(evidence),
+        "evidence_shape": _evidence_shape(finding, evidence),
+        "action": "no_change",
+        "file": finding.get("file"),
+        "line": finding.get("line"),
+        "severity": finding.get("severity"),
+        "message": message,
+        "evidence": evidence,
+    }
+
+
+def _alias(value: str, fallback: str, pattern: str) -> str:
+    return value if re.fullmatch(pattern, value) else fallback
+
+
+def _looks_like_python_report(report: dict[str, Any]) -> bool:
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+    if summary.get("production_files") or summary.get("test_files"):
+        return True
+    findings = report.get("findings") if isinstance(report.get("findings"), list) else []
+    return any(isinstance(item, dict) and _path_kind(item.get("file")) in {"production", "test"} for item in findings)
+
+
+def _coverage_supplied(notes: list[Any]) -> bool:
+    rendered_notes = "\n".join(item for item in notes if isinstance(item, str))
+    return "PTG002 skipped: no coverage XML was provided." not in rendered_notes
+
+
+def _path_kind(value: Any) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    normalized = value.replace("\\", "/").lower()
+    name = normalized.rsplit("/", 1)[-1]
+    if "/tests/" in f"/{normalized}" or name.startswith("test_") or name.endswith("_test.py"):
+        return "test"
+    if normalized.endswith(".md") or normalized.startswith("docs/"):
+        return "docs"
+    if name in {"pyproject.toml", "setup.py", "tox.ini"} or normalized.startswith(".github/"):
+        return "config"
+    if normalized.endswith(".py"):
+        return "production"
+    return "unknown"
+
+
+def _symbol_kind(evidence: str, message: str) -> str:
+    text = f"{evidence} {message}".lower()
+    if "method" in text or re.search(r"\bclass\.[a-z_]", text):
+        return "method"
+    if "class" in text:
+        return "class"
+    if "module" in text:
+        return "module"
+    if "symbol" in text or "function" in text or "(" in evidence:
+        return "function"
+    return "unknown"
+
+
+def _dependency_kind(evidence: str) -> str:
+    text = evidence.lower()
+    if "dependency_kind=external" in text or "external" in text:
+        return "external"
+    if "dependency_kind=internal" in text or "internal" in text or "dependency" in text:
+        return "internal"
+    if "mock" in text:
+        return "unknown"
+    return "none"
+
+
+def _evidence_shape(finding: dict[str, Any], evidence: str) -> str:
+    rule_id = finding.get("rule_id")
+    lowered = evidence.lower()
+    if rule_id == "PTG001":
+        return "production changed without test file change"
+    if rule_id == "PTG002":
+        return "changed line uncovered by supplied coverage"
+    if rule_id == "PTG003":
+        return "weak assertion added in changed test"
+    if rule_id == "PTG004":
+        return "test validation scope weakened"
+    if rule_id == "PTG005":
+        if "direct_changed_symbol_mock" in lowered:
+            return "changed test mocks changed symbol directly"
+        if "owner" in lowered or "dependency" in lowered or "changed call" in lowered:
+            return "changed test mocks dependency called from changed line"
+        return "mock boundary relationship signal"
+    if rule_id == "PTG006":
+        if "kind=comparison" in lowered or "comparison" in lowered:
+            return "comparison boundary probe survived configured tests"
+        return "targeted probe survived configured tests"
+    return "rule finding signal"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", type=Path, help="JSON report written by pr-test-guard check --json-output")
+    parser.add_argument("-o", "--output", type=Path, help="path for the local raw review draft; stdout when omitted")
+    parser.add_argument("--review-id", default="review_001", help="sanitized-safe review id")
+    parser.add_argument("--repo-alias", default="repo_001", help="sanitized-safe repository alias, for example repo_001")
+    parser.add_argument("--pr-alias", default="pr_001", help="sanitized-safe pull request alias, for example pr_001")
+    parser.add_argument(
+        "--test-framework",
+        default="unknown",
+        choices=sorted(VALID_TEST_FRAMEWORKS),
+        help="coarse test framework label for the review environment",
+    )
+    parser.add_argument(
+        "--test-command-shape",
+        default="unknown",
+        choices=sorted(VALID_COMMAND_SHAPES),
+        help="coarse test command shape; do not include the raw command",
+    )
+    args = parser.parse_args()
+
+    try:
+        draft = draft_review(
+            load_json(args.report),
+            review_id=args.review_id,
+            repo_alias=args.repo_alias,
+            pr_alias=args.pr_alias,
+            test_framework=args.test_framework,
+            test_command_shape=args.test_command_shape,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        write_json(args.output, draft)
+    else:
+        print(json.dumps(draft, indent=2, sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/summarize_dogfood_reviews.py
+++ b/scripts/summarize_dogfood_reviews.py
@@ -36,6 +36,8 @@ def load_records(root: Path) -> list[dict[str, Any]]:
 def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
     by_rule: dict[str, dict[str, Any]] = {}
     category_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    evidence_shape_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    action_counts: dict[str, Counter[str]] = defaultdict(Counter)
 
     for record in records:
         findings = record.get("findings")
@@ -47,6 +49,8 @@ def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
             rule_id = finding.get("rule_id")
             label = finding.get("review_label")
             category = finding.get("category")
+            evidence_shape = finding.get("evidence_shape")
+            action = finding.get("action")
             if not isinstance(rule_id, str) or label not in LABELS:
                 continue
             bucket = by_rule.setdefault(
@@ -54,7 +58,10 @@ def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
                 {
                     "total": 0,
                     "labels": {item: 0 for item in LABELS},
+                    "label_rates": {item: 0.0 for item in LABELS},
                     "top_categories": [],
+                    "top_evidence_shapes": [],
+                    "actions": {},
                     "recommended_next_actions": [],
                 },
             )
@@ -62,12 +69,26 @@ def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
             bucket["labels"][label] += 1
             if isinstance(category, str) and category:
                 category_counts[rule_id][category] += 1
+            if isinstance(evidence_shape, str) and evidence_shape:
+                evidence_shape_counts[rule_id][evidence_shape] += 1
+            if isinstance(action, str) and action:
+                action_counts[rule_id][action] += 1
 
     for rule_id, bucket in by_rule.items():
+        total = bucket["total"]
+        bucket["label_rates"] = {
+            label: round(count / total, 3) if total else 0.0
+            for label, count in bucket["labels"].items()
+        }
         bucket["top_categories"] = [
             {"category": category, "count": count}
             for category, count in category_counts[rule_id].most_common(5)
         ]
+        bucket["top_evidence_shapes"] = [
+            {"evidence_shape": shape, "count": count}
+            for shape, count in evidence_shape_counts[rule_id].most_common(5)
+        ]
+        bucket["actions"] = dict(sorted(action_counts[rule_id].items()))
         bucket["recommended_next_actions"] = _recommended_actions(bucket)
 
     return {

--- a/tests/test_dogfood_workflow.py
+++ b/tests/test_dogfood_workflow.py
@@ -20,6 +20,64 @@ def load_script(name: str):
 
 sanitize_module = load_script("sanitize_dogfood_review.py")
 summary_module = load_script("summarize_dogfood_reviews.py")
+draft_module = load_script("draft_dogfood_review.py")
+
+
+def test_draft_review_from_check_report_preserves_local_review_context() -> None:
+    report = {
+        "base": "HEAD~1",
+        "head": "abc123",
+        "summary": {"changed_files": 2, "production_files": 1, "test_files": 1, "findings": 2},
+        "notes": ["PTG002 skipped: no coverage XML was provided."],
+        "probes": {"enabled": True, "generated": 1, "applied": 1, "survived": 1, "baseline_passed": True},
+        "findings": [
+            {
+                "rule_id": "PTG005",
+                "severity": "warning",
+                "file": "tests/payments/test_private_gateway.py",
+                "line": 12,
+                "message": "Mock overlaps changed code.",
+                "evidence": "relationship_type=internal_dependency_mock; changed owner symbol=PrivatePaymentService.charge",
+            },
+            {
+                "rule_id": "PTG006",
+                "severity": "warning",
+                "file": "payments/service.py",
+                "line": 9,
+                "message": "A bounded targeted probe survived.",
+                "evidence": "baseline_passed=true; kind=comparison_boundary; mutation=>= -> >",
+            },
+        ],
+    }
+
+    draft = draft_module.draft_review(
+        report,
+        review_id="review_123",
+        repo_alias="repo_123",
+        pr_alias="pr_456",
+        test_framework="pytest",
+        test_command_shape="pytest",
+    )
+
+    assert draft["source"]["repo_alias"] == "repo_123"
+    assert draft["environment"] == {
+        "language": "python",
+        "test_framework": "pytest",
+        "coverage_supplied": False,
+        "deep_enabled": True,
+        "test_command_shape": "pytest",
+    }
+    assert draft["findings"][0]["review_label"] == "needs_more_context"
+    assert draft["findings"][0]["path_kind"] == "test"
+    assert draft["findings"][0]["dependency_kind"] == "internal"
+    assert draft["findings"][0]["evidence_shape"] == "changed test mocks dependency called from changed line"
+    assert draft["findings"][1]["path_kind"] == "production"
+    assert draft["findings"][1]["evidence_shape"] == "comparison boundary probe survived configured tests"
+
+    sanitized = sanitize_module.sanitize_review(draft)
+    rendered = json.dumps(sanitized)
+    assert "PrivatePaymentService" not in rendered
+    assert "test_private_gateway.py" not in rendered
 
 
 def test_sanitize_review_drops_repository_specific_details() -> None:
@@ -119,9 +177,17 @@ def test_summarize_records_counts_labels_and_categories() -> None:
     assert summary["finding_count"] == 3
     assert summary["rules"]["PTG005"]["labels"]["false_positive"] == 1
     assert summary["rules"]["PTG005"]["labels"]["unclear"] == 1
+    assert summary["rules"]["PTG005"]["label_rates"]["false_positive"] == 0.5
     assert summary["rules"]["PTG005"]["top_categories"] == [
         {"category": "legitimate_internal_helper_mock", "count": 2}
     ]
+    assert summary["rules"]["PTG005"]["top_evidence_shapes"] == [
+        {"evidence_shape": "changed test mocks dependency called from changed line", "count": 2}
+    ]
+    assert summary["rules"]["PTG005"]["actions"] == {
+        "add_fixture": 1,
+        "improve_evidence": 1,
+    }
     assert "add_negative_control_fixture" in summary["rules"]["PTG005"]["recommended_next_actions"]
     assert summary["rules"]["PTG006"]["recommended_next_actions"] == ["keep_rule_behavior"]
 


### PR DESCRIPTION
## Summary
- add a draft_dogfood_review.py helper that turns check JSON reports into local raw dogfood review drafts
- preserve local-only review context while keeping sanitize_dogfood_review.py as the public-safe conversion step
- expand dogfood summaries with label rates, evidence-shape counts, and action counts
- document the JSON report -> raw draft -> sanitized record workflow

## Validation
- .venv/bin/python -m pytest tests/test_dogfood_workflow.py
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- git diff --check