### PR TITLE
release: prepare v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <h1 align="center">PR Test Guard</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.5-brightgreen.svg" alt="release v0.2.5" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/release-v0.3.0-brightgreen.svg" alt="release v0.3.0" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /> <img src="https://img.shields.io/badge/output-JSON%20%7C%20Markdown-lightgrey.svg" alt="JSON and Markdown output" /> <img src="https://img.shields.io/badge/scope-Python%2Fpytest-yellow.svg" alt="Python pytest scope" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **Lightweight, rule-based test-quality checks for pull requests.**
 
 PR Test Guard helps reviewers spot PRs that look tested but still carry obvious test-quality risks: missing test changes, uncovered changed code, weak assertions, mismatched tests, or mocks that may replace the behavior under review.
 
-The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.2.5` adds JSON report artifact output on top of configurable rule policy and richer GitHub output.
+The project is CLI-first and designed to fit naturally into CI. Its default behavior is advisory: surface actionable signals for reviewers, and let each repository decide which rules, if any, should become merge-blocking policy. Version `0.3.0` adds a dogfooding workflow that turns JSON reports into local review drafts and shareable sanitized summaries.
 
 | | |
 | --- | --- |
@@ -104,7 +104,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tigerless-labs/pr-test-guard@v0.2.5
+      - uses: tigerless-labs/pr-test-guard@v0.3.0
         with:
           base: origin/${{ github.base_ref }}
           config: .pr-test-guard.yml
@@ -113,7 +113,7 @@ jobs:
 Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflow has already installed the target repository's own test dependencies and that the configured test command passes before PR Test Guard runs:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.2.5
+      - uses: tigerless-labs/pr-test-guard@v0.3.0
         with:
           base: origin/${{ github.base_ref }}
           coverage: coverage.xml
@@ -126,7 +126,7 @@ Coverage and deep probes are opt-in Action inputs. Deep mode assumes the workflo
 The Action can also write and optionally upload a structured JSON report:
 
 ```yaml
-      - uses: tigerless-labs/pr-test-guard@v0.2.5
+      - uses: tigerless-labs/pr-test-guard@v0.3.0
         with:
           base: origin/${{ github.base_ref }}
           json-output: pr-test-guard-report.json
@@ -277,11 +277,11 @@ Patch-coverage tools answer whether changed lines were executed. PR Test Guard k
 - [Rule Fixtures](docs/rule-fixtures.md): how controlled fixtures define expected rule behavior for regression testing.
 - [Validation Strategy](docs/validation-strategy.md): how to validate rule usefulness, false positives, and real-world behavior.
 - [Runner Artifacts](docs/runner-artifacts.md): what the current regression-fixture runner emits.
-- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.2.5` release.
+- [Roadmap](docs/roadmap.md): the lightweight CLI and GitHub Action path from the current `0.3.0` release.
 
 ## Current Scope
 
-Version `0.2.5` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
+Version `0.3.0` supports direct Python/pytest PR analysis from the current Git repository and a reusable advisory GitHub Action. The direct checker currently surfaces:
 
 - production-code changes with no test-file change;
 - uncovered changed Python lines when a coverage XML report is supplied;
@@ -292,6 +292,7 @@ Version `0.2.5` supports direct Python/pytest PR analysis from the current Git r
 - optional bounded targeted probes that survive an explicit test command.
 - configurable rule policy through `.pr-test-guard.yml`, `--config`, `--no-config`, and `--fail-on`.
 - optional JSON report output through `--json-output` and GitHub artifact upload.
+- dogfooding helpers that draft local review records from JSON reports and summarize sanitized reviewer feedback.
 
 It still does **not** include:
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -110,6 +110,6 @@ CI integration should be advisory by default. Repositories can opt into stricter
 
 ## Current Limits
 
-Version `0.2.5` provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, JSON report artifacts, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
+Version `0.3.0` provides a repository-native `check` command, a reusable GitHub Action, configurable rule policy, JSON report artifacts, dogfooding review-draft helpers, deterministic related-test context, AST-scoped targeted probes, and PTG005 constrained dependency-mock suppression for the current Python/pytest scope. The checker is intentionally conservative: it does not infer full PR correctness, automatically discover every project's test command, or treat heuristic signals as merge-blocking failures unless the repository explicitly configures that policy.
 
 The immediate engineering goal is real-PR dogfooding and false-positive reduction. Controlled fixtures remain regression tests for the tool rather than a public benchmark.

--- a/docs/real-pr-input.md
+++ b/docs/real-pr-input.md
@@ -103,7 +103,7 @@ The root `action.yml` wraps the same CLI/core. A consumer repository checks out 
   with:
     fetch-depth: 0
 
-- uses: tigerless-labs/pr-test-guard@v0.2.5
+- uses: tigerless-labs/pr-test-guard@v0.3.0
   with:
     base: origin/${{ github.base_ref }}
 ```
@@ -113,7 +113,7 @@ The Action emits GitHub warning annotations and appends a job summary. Findings 
 To use repository policy:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.5
+- uses: tigerless-labs/pr-test-guard@v0.3.0
   with:
     base: origin/${{ github.base_ref }}
     config: .pr-test-guard.yml
@@ -122,7 +122,7 @@ To use repository policy:
 To enforce a high-confidence rule without a config file:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.5
+- uses: tigerless-labs/pr-test-guard@v0.3.0
   with:
     base: origin/${{ github.base_ref }}
     fail-on: PTG006
@@ -133,7 +133,7 @@ Rules configured as `error` emit GitHub error annotations and make the Action fa
 The Action also supports JSON report artifacts:
 
 ```yaml
-- uses: tigerless-labs/pr-test-guard@v0.2.5
+- uses: tigerless-labs/pr-test-guard@v0.3.0
   with:
     base: origin/${{ github.base_ref }}
     json-output: pr-test-guard-report.json

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,25 @@
+# PR Test Guard v0.3.0
+
+Version `0.3.0` is a minor release focused on making real-PR dogfooding easier to run and summarize from checker JSON reports.
+
+## What Changed
+
+- Added `scripts/draft_dogfood_review.py` to turn `pr-test-guard check --json-output` reports into local raw dogfood review drafts.
+- Preserved local-only review context in drafts, including file, line, severity, message, and evidence, so reviewers can label findings before sanitizing them.
+- Kept `scripts/sanitize_dogfood_review.py` as the public-safe conversion step for removing repository-specific details before records are shared or committed.
+- Expanded dogfood summaries with per-rule label rates, top evidence shapes, and action counts.
+- Documented the JSON report -> raw draft -> sanitized record -> aggregate summary workflow in the dogfooding guide.
+
+## Compatibility
+
+- Default checker behavior, CLI options, and GitHub Action inputs remain compatible with `0.2.5`.
+- The new dogfooding draft helper is development workflow tooling and does not affect normal `pr-test-guard check` output.
+- Sanitized public records continue to use schema version `1`.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest tests
+.venv/bin/python -m pr_test_guard validate-cases --run
+git diff --check
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 PR Test Guard is a lightweight PR test-quality tool: run fast checks on a pull-request diff, explain what triggered, and fit naturally into local CLI and CI workflows.
 
-Version `0.2.5` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, JSON report artifacts, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
+Version `0.3.0` keeps the first public-ready shape from `0.1.0`, adds deterministic related-test context, configurable rule policy, richer GitHub output, JSON report artifacts, dogfooding review-draft helpers, improves PTG005/PTG006 evidence, adds AST-scoped targeted probe generation for the optional deep path, reduces PTG005 false positives for constrained dependency mocks, and fixes PTG006 rerun correctness around stale Python bytecode.
 
-## What Exists in 0.2.5
+## What Exists in 0.3.0
 
 - `pr-test-guard` / `python -m pr_test_guard` entrypoints;
 - `pr-test-guard check --base <base-ref>` for repository-native PR analysis;
@@ -17,6 +17,7 @@ Version `0.2.5` keeps the first public-ready shape from `0.1.0`, adds determinis
 - text, JSON, and GitHub Actions output;
 - `.pr-test-guard.*` configuration for rule `off` / `warn` / `error`, ignored paths, related-test display limits, and one-off `--fail-on` CI policy;
 - optional `--json-output` report writing and GitHub artifact upload;
+- dogfooding helpers for drafting raw local review records from JSON reports, sanitizing them, and summarizing aggregate reviewer feedback;
 - reusable root `action.yml` with advisory warnings/job summary;
 - executable Python/pytest regression fixtures;
 - normalized real-PR bundle compatibility for development artifacts.

--- a/docs/runner-artifacts.md
+++ b/docs/runner-artifacts.md
@@ -94,7 +94,7 @@ Human-readable report for the fixture. Findings are review signals and do not ce
 
 ## Stability
 
-Version `0.2.5` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
+Version `0.3.0` remains early. Artifact fields may evolve as the older fixture runner continues to follow the direct PR-facing CLI.
 
 Changes should preserve two properties:
 

--- a/pr_test_guard/version.py
+++ b/pr_test_guard/version.py
@@ -1,3 +1,3 @@
 """Project version."""
 
-__version__ = "0.2.5"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-test-guard"
-version = "0.2.5"
+version = "0.3.0"
 description = "Lightweight, rule-based test-quality checks for pull requests."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ import pr_test_guard
 
 
 def test_package_version_is_current() -> None:
-    assert pr_test_guard.__version__ == "0.2.5"
+    assert pr_test_guard.__version__ == "0.3.0"


### PR DESCRIPTION
## Summary
- bump package and documented release version to v0.3.0
- add v0.3.0 release notes for the dogfooding workflow
- update README, roadmap, methodology, real-PR input, and runner artifact docs for the current release

## Validation
- .venv/bin/python -m pytest tests
- .venv/bin/python -m pr_test_guard validate-cases --run
- .venv/bin/python -m pr_test_guard version
- git diff --check